### PR TITLE
Add dependency requirement to gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Added support for the Anonymous IP, ASN, Connection Type, Domain, and ISP
   databases.
+* Added missing dependency on maxmind-db to the gemspec. Reported by Sean
+  Dilda. GitHub #4.
 
 ## 0.0.1 (2020-01-09)
 

--- a/maxmind-geoip2.gemspec
+++ b/maxmind-geoip2.gemspec
@@ -19,4 +19,6 @@ Gem::Specification.new do |s|
     'source_code_uri' => 'https://github.com/maxmind/GeoIP2-ruby',
   }
   s.required_ruby_version = '>= 2.4.0'
+
+  s.add_runtime_dependency 'maxmind-db', ['~> 1.1']
 end


### PR DESCRIPTION
While this was in the Gemfile, that isn't used by the gem command, so we
have to list runtime dependencies in the gemspec.