### PR TITLE
Always define module constants

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,10 +31,6 @@ Style/TrailingCommaInHashLiteral:
 Style/NegatedIf:
     Enabled: false
 
-# This reduces indentation.
-Style/ClassAndModuleChildren:
-    EnforcedStyle: compact
-
 # This doesn't always make sense.
 Style/IfUnlessModifier:
     Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.3.0
+
+* Modules are now always be defined. Previously we used a shorthand syntax
+  which meant including individual classes could leave module constants
+  undefined.
+
 ## 0.2.0 (2020-02-26)
 
 * Added support for the GeoIP2 Precision web services: Country, City, and

--- a/lib/maxmind/geoip2/client.rb
+++ b/lib/maxmind/geoip2/client.rb
@@ -7,307 +7,309 @@ require 'maxmind/geoip2/model/city'
 require 'maxmind/geoip2/model/country'
 require 'maxmind/geoip2/model/insights'
 
-module MaxMind::GeoIP2
-  # This class provides a client API for all the
-  # {https://dev.maxmind.com/geoip/geoip2/web-services/ GeoIP2 Precision web
-  # services}. The services are Country, City, and Insights. Each service
-  # returns a different set of data about an IP address, with Country returning
-  # the least data and Insights the most.
-  #
-  # Each web service is represented by a different model class, and these model
-  # classes in turn contain multiple record classes. The record classes have
-  # attributes which contain data about the IP address.
-  #
-  # If the web service does not return a particular piece of data for an IP
-  # address, the associated attribute is not populated.
-  #
-  # The web service may not return any information for an entire record, in
-  # which case all of the attributes for that record class will be empty.
-  #
-  # == Usage
-  #
-  # The basic API for this class is the same for all of the web service end
-  # points. First you create a web service client object with your MaxMind
-  # account ID and license key, then you call the method corresponding to a
-  # specific end point, passing it the IP address you want to look up.
-  #
-  # If the request succeeds, the method call will return a model class for the
-  # service you called. This model in turn contains multiple record classes,
-  # each of which represents part of the data returned by the web service.
-  #
-  # If the request fails, the client class throws an exception.
-  #
-  # == Example
-  #
-  #   require 'maxmind/geoip2'
-  #
-  #   client = MaxMind::GeoIP2::Client.new(
-  #     account_id: 42,
-  #     license_key: 'abcdef123456',
-  #   )
-  #
-  #   # Replace 'city' with the method corresponding to the web service you
-  #   # are using, e.g., 'country', 'insights'.
-  #   record = client.city('128.101.101.101')
-  #
-  #   puts record.country.iso_code
-  class Client
-    # rubocop:disable Metrics/ParameterLists
+module MaxMind
+  module GeoIP2
+    # This class provides a client API for all the
+    # {https://dev.maxmind.com/geoip/geoip2/web-services/ GeoIP2 Precision web
+    # services}. The services are Country, City, and Insights. Each service
+    # returns a different set of data about an IP address, with Country returning
+    # the least data and Insights the most.
+    #
+    # Each web service is represented by a different model class, and these model
+    # classes in turn contain multiple record classes. The record classes have
+    # attributes which contain data about the IP address.
+    #
+    # If the web service does not return a particular piece of data for an IP
+    # address, the associated attribute is not populated.
+    #
+    # The web service may not return any information for an entire record, in
+    # which case all of the attributes for that record class will be empty.
+    #
+    # == Usage
+    #
+    # The basic API for this class is the same for all of the web service end
+    # points. First you create a web service client object with your MaxMind
+    # account ID and license key, then you call the method corresponding to a
+    # specific end point, passing it the IP address you want to look up.
+    #
+    # If the request succeeds, the method call will return a model class for the
+    # service you called. This model in turn contains multiple record classes,
+    # each of which represents part of the data returned by the web service.
+    #
+    # If the request fails, the client class throws an exception.
+    #
+    # == Example
+    #
+    #   require 'maxmind/geoip2'
+    #
+    #   client = MaxMind::GeoIP2::Client.new(
+    #     account_id: 42,
+    #     license_key: 'abcdef123456',
+    #   )
+    #
+    #   # Replace 'city' with the method corresponding to the web service you
+    #   # are using, e.g., 'country', 'insights'.
+    #   record = client.city('128.101.101.101')
+    #
+    #   puts record.country.iso_code
+    class Client
+      # rubocop:disable Metrics/ParameterLists
 
-    # Create a Client that may be used to query a GeoIP2 Precision web service.
-    #
-    # Once created, the Client is safe to use for lookups from multiple
-    # threads.
-    #
-    # @param account_id [Integer] your MaxMind account ID.
-    #
-    # @param license_key [String] your MaxMind license key.
-    #
-    # @param locales [Array<String>] a list of locale codes to use in the name
-    #   property from most preferred to least preferred.
-    #
-    # @param host [String] the host to use when querying the web service.
-    #
-    # @param timeout [Integer] the number of seconds to wait for a request
-    #   before timing out. If 0, no timeout is set.
-    #
-    # @param proxy_address [String] proxy address to use, if any.
-    #
-    # @param proxy_port [Integer] proxy port to use, if any.
-    #
-    # @param proxy_username [String] proxy username to use, if any.
-    #
-    # @param proxy_password [String] proxy password to use, if any.
-    def initialize(
-      account_id:,
-      license_key:,
-      locales: ['en'],
-      host: 'geoip.maxmind.com',
-      timeout: 0,
-      proxy_address: '',
-      proxy_port: 0,
-      proxy_username: '',
-      proxy_password: ''
-    )
-      @account_id = account_id
-      @license_key = license_key
-      @locales = locales
-      @host = host
-      @timeout = timeout
-      @proxy_address = proxy_address
-      @proxy_port = proxy_port
-      @proxy_username = proxy_username
-      @proxy_password = proxy_password
-    end
-    # rubocop:enable Metrics/ParameterLists
+      # Create a Client that may be used to query a GeoIP2 Precision web service.
+      #
+      # Once created, the Client is safe to use for lookups from multiple
+      # threads.
+      #
+      # @param account_id [Integer] your MaxMind account ID.
+      #
+      # @param license_key [String] your MaxMind license key.
+      #
+      # @param locales [Array<String>] a list of locale codes to use in the name
+      #   property from most preferred to least preferred.
+      #
+      # @param host [String] the host to use when querying the web service.
+      #
+      # @param timeout [Integer] the number of seconds to wait for a request
+      #   before timing out. If 0, no timeout is set.
+      #
+      # @param proxy_address [String] proxy address to use, if any.
+      #
+      # @param proxy_port [Integer] proxy port to use, if any.
+      #
+      # @param proxy_username [String] proxy username to use, if any.
+      #
+      # @param proxy_password [String] proxy password to use, if any.
+      def initialize(
+        account_id:,
+        license_key:,
+        locales: ['en'],
+        host: 'geoip.maxmind.com',
+        timeout: 0,
+        proxy_address: '',
+        proxy_port: 0,
+        proxy_username: '',
+        proxy_password: ''
+      )
+        @account_id = account_id
+        @license_key = license_key
+        @locales = locales
+        @host = host
+        @timeout = timeout
+        @proxy_address = proxy_address
+        @proxy_port = proxy_port
+        @proxy_username = proxy_username
+        @proxy_password = proxy_password
+      end
+      # rubocop:enable Metrics/ParameterLists
 
-    # This method calls the GeoIP2 Precision City web service.
-    #
-    # @param ip_address [String] IPv4 or IPv6 address as a string. If no
-    #   address is provided, the address that the web service is called from is
-    #   used.
-    #
-    # @raise [HTTP::Error] if there was an error performing the HTTP request,
-    #   such as an error connecting.
-    #
-    # @raise [JSON::ParserError] if there was invalid JSON in the response.
-    #
-    # @raise [HTTPError] if there was a problem with the HTTP response, such as
-    #   an unexpected HTTP status code.
-    #
-    # @raise [AddressInvalidError] if the web service believes the IP address
-    #   to be invalid or missing.
-    #
-    # @raise [AddressNotFoundError] if the IP address was not found.
-    #
-    # @raise [AddressReservedError] if the IP address is reserved.
-    #
-    # @raise [AuthenticationError] if there was a problem authenticating to the
-    #   web service, such as an invalid or missing license key.
-    #
-    # @raise [InsufficientFundsError] if your account is out of credit.
-    #
-    # @raise [PermissionRequiredError] if your account does not have permission
-    #   to use the web service.
-    #
-    # @raise [InvalidRequestError] if the web service responded with an error
-    #   and there is no more specific error to raise.
-    #
-    # @return [MaxMind::GeoIP2::Model::City]
-    def city(ip_address = 'me')
-      response_for('city', MaxMind::GeoIP2::Model::City, ip_address)
-    end
-
-    # This method calls the GeoIP2 Precision Country web service.
-    #
-    # @param ip_address [String] IPv4 or IPv6 address as a string. If no
-    #   address is provided, the address that the web service is called from is
-    #   used.
-    #
-    # @raise [HTTP::Error] if there was an error performing the HTTP request,
-    #   such as an error connecting.
-    #
-    # @raise [JSON::ParserError] if there was invalid JSON in the response.
-    #
-    # @raise [HTTPError] if there was a problem with the HTTP response, such as
-    #   an unexpected HTTP status code.
-    #
-    # @raise [AddressInvalidError] if the web service believes the IP address
-    #   to be invalid or missing.
-    #
-    # @raise [AddressNotFoundError] if the IP address was not found.
-    #
-    # @raise [AddressReservedError] if the IP address is reserved.
-    #
-    # @raise [AuthenticationError] if there was a problem authenticating to the
-    #   web service, such as an invalid or missing license key.
-    #
-    # @raise [InsufficientFundsError] if your account is out of credit.
-    #
-    # @raise [PermissionRequiredError] if your account does not have permission
-    #   to use the web service.
-    #
-    # @raise [InvalidRequestError] if the web service responded with an error
-    #   and there is no more specific error to raise.
-    #
-    # @return [MaxMind::GeoIP2::Model::Country]
-    def country(ip_address = 'me')
-      response_for('country', MaxMind::GeoIP2::Model::Country, ip_address)
-    end
-
-    # This method calls the GeoIP2 Precision Insights web service.
-    #
-    # @param ip_address [String] IPv4 or IPv6 address as a string. If no
-    #   address is provided, the address that the web service is called from is
-    #   used.
-    #
-    # @raise [HTTP::Error] if there was an error performing the HTTP request,
-    #   such as an error connecting.
-    #
-    # @raise [JSON::ParserError] if there was invalid JSON in the response.
-    #
-    # @raise [HTTPError] if there was a problem with the HTTP response, such as
-    #   an unexpected HTTP status code.
-    #
-    # @raise [AddressInvalidError] if the web service believes the IP address
-    #   to be invalid or missing.
-    #
-    # @raise [AddressNotFoundError] if the IP address was not found.
-    #
-    # @raise [AddressReservedError] if the IP address is reserved.
-    #
-    # @raise [AuthenticationError] if there was a problem authenticating to the
-    #   web service, such as an invalid or missing license key.
-    #
-    # @raise [InsufficientFundsError] if your account is out of credit.
-    #
-    # @raise [PermissionRequiredError] if your account does not have permission
-    #   to use the web service.
-    #
-    # @raise [InvalidRequestError] if the web service responded with an error
-    #   and there is no more specific error to raise.
-    #
-    # @return [MaxMind::GeoIP2::Model::Insights]
-    def insights(ip_address = 'me')
-      response_for('insights', MaxMind::GeoIP2::Model::Insights, ip_address)
-    end
-
-    private
-
-    def response_for(endpoint, model_class, ip_address)
-      record = get(endpoint, ip_address)
-
-      model_class.new(record, @locales)
-    end
-
-    # rubocop:disable Metrics/CyclomaticComplexity
-    # rubocop:disable Metrics/PerceivedComplexity
-    def get(endpoint, ip_address)
-      url = 'https://' + @host + '/geoip/v2.1/' + endpoint + '/' + ip_address
-
-      headers = HTTP.basic_auth(user: @account_id, pass: @license_key)
-                    .headers(
-                      accept: 'application/json',
-                      user_agent: 'MaxMind-GeoIP2-ruby',
-                    )
-      timeout = @timeout > 0 ? headers.timeout(@timeout) : headers
-
-      proxy = timeout
-      if @proxy_address != ''
-        opts = {}
-        opts[:proxy_port] = @proxy_port if @proxy_port != 0
-        opts[:proxy_username] = @proxy_username if @proxy_username != ''
-        opts[:proxy_password] = @proxy_password if @proxy_password != ''
-        proxy = timeout.via(@proxy_address, opts)
+      # This method calls the GeoIP2 Precision City web service.
+      #
+      # @param ip_address [String] IPv4 or IPv6 address as a string. If no
+      #   address is provided, the address that the web service is called from is
+      #   used.
+      #
+      # @raise [HTTP::Error] if there was an error performing the HTTP request,
+      #   such as an error connecting.
+      #
+      # @raise [JSON::ParserError] if there was invalid JSON in the response.
+      #
+      # @raise [HTTPError] if there was a problem with the HTTP response, such as
+      #   an unexpected HTTP status code.
+      #
+      # @raise [AddressInvalidError] if the web service believes the IP address
+      #   to be invalid or missing.
+      #
+      # @raise [AddressNotFoundError] if the IP address was not found.
+      #
+      # @raise [AddressReservedError] if the IP address is reserved.
+      #
+      # @raise [AuthenticationError] if there was a problem authenticating to the
+      #   web service, such as an invalid or missing license key.
+      #
+      # @raise [InsufficientFundsError] if your account is out of credit.
+      #
+      # @raise [PermissionRequiredError] if your account does not have permission
+      #   to use the web service.
+      #
+      # @raise [InvalidRequestError] if the web service responded with an error
+      #   and there is no more specific error to raise.
+      #
+      # @return [MaxMind::GeoIP2::Model::City]
+      def city(ip_address = 'me')
+        response_for('city', MaxMind::GeoIP2::Model::City, ip_address)
       end
 
-      response = proxy.get(url)
-
-      body = response.to_s
-      is_json = response.headers[:content_type]&.include?('json')
-
-      if response.status.client_error?
-        return handle_client_error(endpoint, response.code, body, is_json)
+      # This method calls the GeoIP2 Precision Country web service.
+      #
+      # @param ip_address [String] IPv4 or IPv6 address as a string. If no
+      #   address is provided, the address that the web service is called from is
+      #   used.
+      #
+      # @raise [HTTP::Error] if there was an error performing the HTTP request,
+      #   such as an error connecting.
+      #
+      # @raise [JSON::ParserError] if there was invalid JSON in the response.
+      #
+      # @raise [HTTPError] if there was a problem with the HTTP response, such as
+      #   an unexpected HTTP status code.
+      #
+      # @raise [AddressInvalidError] if the web service believes the IP address
+      #   to be invalid or missing.
+      #
+      # @raise [AddressNotFoundError] if the IP address was not found.
+      #
+      # @raise [AddressReservedError] if the IP address is reserved.
+      #
+      # @raise [AuthenticationError] if there was a problem authenticating to the
+      #   web service, such as an invalid or missing license key.
+      #
+      # @raise [InsufficientFundsError] if your account is out of credit.
+      #
+      # @raise [PermissionRequiredError] if your account does not have permission
+      #   to use the web service.
+      #
+      # @raise [InvalidRequestError] if the web service responded with an error
+      #   and there is no more specific error to raise.
+      #
+      # @return [MaxMind::GeoIP2::Model::Country]
+      def country(ip_address = 'me')
+        response_for('country', MaxMind::GeoIP2::Model::Country, ip_address)
       end
 
-      if response.status.server_error?
-        raise HTTPError,
-              "Received server error response (#{response.code}) for #{endpoint} with body #{body}"
+      # This method calls the GeoIP2 Precision Insights web service.
+      #
+      # @param ip_address [String] IPv4 or IPv6 address as a string. If no
+      #   address is provided, the address that the web service is called from is
+      #   used.
+      #
+      # @raise [HTTP::Error] if there was an error performing the HTTP request,
+      #   such as an error connecting.
+      #
+      # @raise [JSON::ParserError] if there was invalid JSON in the response.
+      #
+      # @raise [HTTPError] if there was a problem with the HTTP response, such as
+      #   an unexpected HTTP status code.
+      #
+      # @raise [AddressInvalidError] if the web service believes the IP address
+      #   to be invalid or missing.
+      #
+      # @raise [AddressNotFoundError] if the IP address was not found.
+      #
+      # @raise [AddressReservedError] if the IP address is reserved.
+      #
+      # @raise [AuthenticationError] if there was a problem authenticating to the
+      #   web service, such as an invalid or missing license key.
+      #
+      # @raise [InsufficientFundsError] if your account is out of credit.
+      #
+      # @raise [PermissionRequiredError] if your account does not have permission
+      #   to use the web service.
+      #
+      # @raise [InvalidRequestError] if the web service responded with an error
+      #   and there is no more specific error to raise.
+      #
+      # @return [MaxMind::GeoIP2::Model::Insights]
+      def insights(ip_address = 'me')
+        response_for('insights', MaxMind::GeoIP2::Model::Insights, ip_address)
       end
 
-      if response.code != 200
-        raise HTTPError,
-              "Received unexpected response (#{response.code}) for #{endpoint} with body #{body}"
+      private
+
+      def response_for(endpoint, model_class, ip_address)
+        record = get(endpoint, ip_address)
+
+        model_class.new(record, @locales)
       end
 
-      handle_success(endpoint, body, is_json)
-    end
-    # rubocop:enable Metrics/CyclomaticComplexity
-    # rubocop:enable Metrics/PerceivedComplexity
+      # rubocop:disable Metrics/CyclomaticComplexity
+      # rubocop:disable Metrics/PerceivedComplexity
+      def get(endpoint, ip_address)
+        url = 'https://' + @host + '/geoip/v2.1/' + endpoint + '/' + ip_address
 
-    # rubocop:disable Metrics/CyclomaticComplexity
-    def handle_client_error(endpoint, status, body, is_json)
-      if !is_json
-        raise HTTPError,
-              "Received client error response (#{status}) for #{endpoint} but it is not JSON: #{body}"
+        headers = HTTP.basic_auth(user: @account_id, pass: @license_key)
+                      .headers(
+                        accept: 'application/json',
+                        user_agent: 'MaxMind-GeoIP2-ruby',
+                      )
+        timeout = @timeout > 0 ? headers.timeout(@timeout) : headers
+
+        proxy = timeout
+        if @proxy_address != ''
+          opts = {}
+          opts[:proxy_port] = @proxy_port if @proxy_port != 0
+          opts[:proxy_username] = @proxy_username if @proxy_username != ''
+          opts[:proxy_password] = @proxy_password if @proxy_password != ''
+          proxy = timeout.via(@proxy_address, opts)
+        end
+
+        response = proxy.get(url)
+
+        body = response.to_s
+        is_json = response.headers[:content_type]&.include?('json')
+
+        if response.status.client_error?
+          return handle_client_error(endpoint, response.code, body, is_json)
+        end
+
+        if response.status.server_error?
+          raise HTTPError,
+                "Received server error response (#{response.code}) for #{endpoint} with body #{body}"
+        end
+
+        if response.code != 200
+          raise HTTPError,
+                "Received unexpected response (#{response.code}) for #{endpoint} with body #{body}"
+        end
+
+        handle_success(endpoint, body, is_json)
       end
+      # rubocop:enable Metrics/CyclomaticComplexity
+      # rubocop:enable Metrics/PerceivedComplexity
 
-      error = JSON.parse(body)
+      # rubocop:disable Metrics/CyclomaticComplexity
+      def handle_client_error(endpoint, status, body, is_json)
+        if !is_json
+          raise HTTPError,
+                "Received client error response (#{status}) for #{endpoint} but it is not JSON: #{body}"
+        end
 
-      if !error.key?('code') || !error.key?('error')
-        raise HTTPError,
-              "Received client error response (#{status}) that is JSON but does not specify code or error keys: #{body}"
+        error = JSON.parse(body)
+
+        if !error.key?('code') || !error.key?('error')
+          raise HTTPError,
+                "Received client error response (#{status}) that is JSON but does not specify code or error keys: #{body}"
+        end
+
+        case error['code']
+        when 'IP_ADDRESS_INVALID', 'IP_ADDRESS_REQUIRED'
+          raise AddressInvalidError, error['error']
+        when 'IP_ADDRESS_NOT_FOUND'
+          raise AddressNotFoundError, error['error']
+        when 'IP_ADDRESS_RESERVED'
+          raise AddressReservedError, error['error']
+        when 'ACCOUNT_ID_REQUIRED',
+              'ACCOUNT_ID_UNKNOWN',
+              'AUTHORIZATION_INVALID',
+              'LICENSE_KEY_REQUIRED'
+          raise AuthenticationError, error['error']
+        when 'INSUFFICIENT_FUNDS'
+          raise InsufficientFundsError, error['error']
+        when 'PERMISSION_REQUIRED'
+          raise PermissionRequiredError, error['error']
+        else
+          raise InvalidRequestError, error['error']
+        end
       end
+      # rubocop:enable Metrics/CyclomaticComplexity
 
-      case error['code']
-      when 'IP_ADDRESS_INVALID', 'IP_ADDRESS_REQUIRED'
-        raise AddressInvalidError, error['error']
-      when 'IP_ADDRESS_NOT_FOUND'
-        raise AddressNotFoundError, error['error']
-      when 'IP_ADDRESS_RESERVED'
-        raise AddressReservedError, error['error']
-      when 'ACCOUNT_ID_REQUIRED',
-            'ACCOUNT_ID_UNKNOWN',
-            'AUTHORIZATION_INVALID',
-            'LICENSE_KEY_REQUIRED'
-        raise AuthenticationError, error['error']
-      when 'INSUFFICIENT_FUNDS'
-        raise InsufficientFundsError, error['error']
-      when 'PERMISSION_REQUIRED'
-        raise PermissionRequiredError, error['error']
-      else
-        raise InvalidRequestError, error['error']
+      def handle_success(endpoint, body, is_json)
+        if !is_json
+          raise HTTPError,
+                "Received a success response for #{endpoint} but it is not JSON: #{body}"
+        end
+
+        JSON.parse(body)
       end
-    end
-    # rubocop:enable Metrics/CyclomaticComplexity
-
-    def handle_success(endpoint, body, is_json)
-      if !is_json
-        raise HTTPError,
-              "Received a success response for #{endpoint} but it is not JSON: #{body}"
-      end
-
-      JSON.parse(body)
     end
   end
 end

--- a/lib/maxmind/geoip2/errors.rb
+++ b/lib/maxmind/geoip2/errors.rb
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 
-# Disable this because I wish to ensure the MaxMind constant is defined,
-# which apparently must be done without using the compact syntax.
-#
-# rubocop:disable Style/ClassAndModuleChildren
-
-# A module for namespacing purposes.
 module MaxMind
   module GeoIP2
     # An AddressNotFoundError means the IP address was not found in the
@@ -45,4 +39,3 @@ module MaxMind
     end
   end
 end
-# rubocop:enable Style/ClassAndModuleChildren

--- a/lib/maxmind/geoip2/model/abstract.rb
+++ b/lib/maxmind/geoip2/model/abstract.rb
@@ -2,26 +2,30 @@
 
 require 'ipaddr'
 
-module MaxMind::GeoIP2::Model
-  # @!visibility private
-  class Abstract
-    def initialize(record)
-      @record = record
+module MaxMind
+  module GeoIP2
+    module Model
+      # @!visibility private
+      class Abstract
+        def initialize(record)
+          @record = record
 
-      ip = IPAddr.new(record['ip_address']).mask(record['prefix_length'])
-      record['network'] = format('%s/%d', ip.to_s, record['prefix_length'])
-    end
+          ip = IPAddr.new(record['ip_address']).mask(record['prefix_length'])
+          record['network'] = format('%s/%d', ip.to_s, record['prefix_length'])
+        end
 
-    protected
+        protected
 
-    def get(key)
-      if @record.nil? || !@record.key?(key)
-        return false if key.start_with?('is_')
+        def get(key)
+          if @record.nil? || !@record.key?(key)
+            return false if key.start_with?('is_')
 
-        return nil
+            return nil
+          end
+
+          @record[key]
+        end
       end
-
-      @record[key]
     end
   end
 end

--- a/lib/maxmind/geoip2/model/anonymous_ip.rb
+++ b/lib/maxmind/geoip2/model/anonymous_ip.rb
@@ -2,62 +2,66 @@
 
 require 'maxmind/geoip2/model/abstract'
 
-module MaxMind::GeoIP2::Model
-  # Model class for the Anonymous IP database.
-  class AnonymousIP < Abstract
-    # This is true if the IP address belongs to any sort of anonymous network.
-    #
-    # @return [Boolean]
-    def anonymous?
-      get('is_anonymous')
-    end
+module MaxMind
+  module GeoIP2
+    module Model
+      # Model class for the Anonymous IP database.
+      class AnonymousIP < Abstract
+        # This is true if the IP address belongs to any sort of anonymous network.
+        #
+        # @return [Boolean]
+        def anonymous?
+          get('is_anonymous')
+        end
 
-    # This is true if the IP address is registered to an anonymous VPN
-    # provider. If a VPN provider does not register subnets under names
-    # associated with them, we will likely only flag their IP ranges using the
-    # hosting_provider? method.
-    #
-    # @return [Boolean]
-    def anonymous_vpn?
-      get('is_anonymous_vpn')
-    end
+        # This is true if the IP address is registered to an anonymous VPN
+        # provider. If a VPN provider does not register subnets under names
+        # associated with them, we will likely only flag their IP ranges using the
+        # hosting_provider? method.
+        #
+        # @return [Boolean]
+        def anonymous_vpn?
+          get('is_anonymous_vpn')
+        end
 
-    # This is true if the IP address belongs to a hosting or VPN provider (see
-    # description of the anonymous_vpn? method).
-    #
-    # @return [Boolean]
-    def hosting_provider?
-      get('is_hosting_provider')
-    end
+        # This is true if the IP address belongs to a hosting or VPN provider (see
+        # description of the anonymous_vpn? method).
+        #
+        # @return [Boolean]
+        def hosting_provider?
+          get('is_hosting_provider')
+        end
 
-    # The IP address that the data in the model is for.
-    #
-    # @return [String]
-    def ip_address
-      get('ip_address')
-    end
+        # The IP address that the data in the model is for.
+        #
+        # @return [String]
+        def ip_address
+          get('ip_address')
+        end
 
-    # The network in CIDR notation associated with the record. In particular,
-    # this is the largest network where all of the fields besides ip_address
-    # have the same value.
-    #
-    # @return [String]
-    def network
-      get('network')
-    end
+        # The network in CIDR notation associated with the record. In particular,
+        # this is the largest network where all of the fields besides ip_address
+        # have the same value.
+        #
+        # @return [String]
+        def network
+          get('network')
+        end
 
-    # This is true if the IP address belongs to a public proxy.
-    #
-    # @return [Boolean]
-    def public_proxy?
-      get('is_public_proxy')
-    end
+        # This is true if the IP address belongs to a public proxy.
+        #
+        # @return [Boolean]
+        def public_proxy?
+          get('is_public_proxy')
+        end
 
-    # This is true if the IP address is a Tor exit node.
-    #
-    # @return [Boolean]
-    def tor_exit_node?
-      get('is_tor_exit_node')
+        # This is true if the IP address is a Tor exit node.
+        #
+        # @return [Boolean]
+        def tor_exit_node?
+          get('is_tor_exit_node')
+        end
+      end
     end
   end
 end

--- a/lib/maxmind/geoip2/model/asn.rb
+++ b/lib/maxmind/geoip2/model/asn.rb
@@ -2,38 +2,42 @@
 
 require 'maxmind/geoip2/model/abstract'
 
-module MaxMind::GeoIP2::Model
-  # Model class for the GeoLite2 ASN database.
-  class ASN < Abstract
-    # The autonomous system number associated with the IP address.
-    #
-    # @return [Integer, nil]
-    def autonomous_system_number
-      get('autonomous_system_number')
-    end
+module MaxMind
+  module GeoIP2
+    module Model
+      # Model class for the GeoLite2 ASN database.
+      class ASN < Abstract
+        # The autonomous system number associated with the IP address.
+        #
+        # @return [Integer, nil]
+        def autonomous_system_number
+          get('autonomous_system_number')
+        end
 
-    # The organization associated with the registered autonomous system number
-    # for the IP address.
-    #
-    # @return [String, nil]
-    def autonomous_system_organization
-      get('autonomous_system_organization')
-    end
+        # The organization associated with the registered autonomous system number
+        # for the IP address.
+        #
+        # @return [String, nil]
+        def autonomous_system_organization
+          get('autonomous_system_organization')
+        end
 
-    # The IP address that the data in the model is for.
-    #
-    # @return [String]
-    def ip_address
-      get('ip_address')
-    end
+        # The IP address that the data in the model is for.
+        #
+        # @return [String]
+        def ip_address
+          get('ip_address')
+        end
 
-    # The network in CIDR notation associated with the record. In particular,
-    # this is the largest network where all of the fields besides ip_address
-    # have the same value.
-    #
-    # @return [String]
-    def network
-      get('network')
+        # The network in CIDR notation associated with the record. In particular,
+        # this is the largest network where all of the fields besides ip_address
+        # have the same value.
+        #
+        # @return [String]
+        def network
+          get('network')
+        end
+      end
     end
   end
 end

--- a/lib/maxmind/geoip2/model/city.rb
+++ b/lib/maxmind/geoip2/model/city.rb
@@ -6,69 +6,73 @@ require 'maxmind/geoip2/record/location'
 require 'maxmind/geoip2/record/postal'
 require 'maxmind/geoip2/record/subdivision'
 
-module MaxMind::GeoIP2::Model
-  # Model class for the data returned by the GeoIP2 City web service and
-  # database. It is also used for GeoLite2 City lookups.
-  #
-  # The only difference between the City and Insights model classes is which
-  # fields in each record may be populated. See
-  # https://dev.maxmind.com/geoip/geoip2/web-services for more details.
-  #
-  # See {MaxMind::GeoIP2::Model::Country} for inherited methods.
-  class City < Country
-    # City data for the IP address.
-    #
-    # @return [MaxMind::GeoIP2::Record::City]
-    attr_reader :city
+module MaxMind
+  module GeoIP2
+    module Model
+      # Model class for the data returned by the GeoIP2 City web service and
+      # database. It is also used for GeoLite2 City lookups.
+      #
+      # The only difference between the City and Insights model classes is which
+      # fields in each record may be populated. See
+      # https://dev.maxmind.com/geoip/geoip2/web-services for more details.
+      #
+      # See {MaxMind::GeoIP2::Model::Country} for inherited methods.
+      class City < Country
+        # City data for the IP address.
+        #
+        # @return [MaxMind::GeoIP2::Record::City]
+        attr_reader :city
 
-    # Location data for the IP address.
-    #
-    # @return [MaxMind::GeoIP2::Record::Location]
-    attr_reader :location
+        # Location data for the IP address.
+        #
+        # @return [MaxMind::GeoIP2::Record::Location]
+        attr_reader :location
 
-    # Postal data for the IP address.
-    #
-    # @return [MaxMind::GeoIP2::Record::Postal]
-    attr_reader :postal
+        # Postal data for the IP address.
+        #
+        # @return [MaxMind::GeoIP2::Record::Postal]
+        attr_reader :postal
 
-    # The country subdivisions for the IP address.
-    #
-    # The number and type of subdivisions varies by country, but a subdivision
-    # is typically a state, province, country, etc. Subdivisions are ordered
-    # from most general (largest) to most specific (smallest).
-    #
-    # If the response did not contain any subdivisions, this attribute will be
-    # an empty array.
-    #
-    # @return [Array<MaxMind::GeoIP2::Record::Subdivision>]
-    attr_reader :subdivisions
+        # The country subdivisions for the IP address.
+        #
+        # The number and type of subdivisions varies by country, but a subdivision
+        # is typically a state, province, country, etc. Subdivisions are ordered
+        # from most general (largest) to most specific (smallest).
+        #
+        # If the response did not contain any subdivisions, this attribute will be
+        # an empty array.
+        #
+        # @return [Array<MaxMind::GeoIP2::Record::Subdivision>]
+        attr_reader :subdivisions
 
-    # @!visibility private
-    def initialize(record, locales)
-      super(record, locales)
-      @city = MaxMind::GeoIP2::Record::City.new(record['city'], locales)
-      @location = MaxMind::GeoIP2::Record::Location.new(record['location'])
-      @postal = MaxMind::GeoIP2::Record::Postal.new(record['postal'])
-      @subdivisions = create_subdivisions(record['subdivisions'], locales)
-    end
+        # @!visibility private
+        def initialize(record, locales)
+          super(record, locales)
+          @city = MaxMind::GeoIP2::Record::City.new(record['city'], locales)
+          @location = MaxMind::GeoIP2::Record::Location.new(record['location'])
+          @postal = MaxMind::GeoIP2::Record::Postal.new(record['postal'])
+          @subdivisions = create_subdivisions(record['subdivisions'], locales)
+        end
 
-    # The most specific subdivision returned.
-    #
-    # If the response did not contain any subdivisions, this method returns
-    # nil.
-    #
-    # @return [MaxMind::GeoIP2::Record::Subdivision, nil]
-    def most_specific_subdivision
-      @subdivisions.last
-    end
+        # The most specific subdivision returned.
+        #
+        # If the response did not contain any subdivisions, this method returns
+        # nil.
+        #
+        # @return [MaxMind::GeoIP2::Record::Subdivision, nil]
+        def most_specific_subdivision
+          @subdivisions.last
+        end
 
-    private
+        private
 
-    def create_subdivisions(subdivisions, locales)
-      return [] if subdivisions.nil?
+        def create_subdivisions(subdivisions, locales)
+          return [] if subdivisions.nil?
 
-      subdivisions.map do |s|
-        MaxMind::GeoIP2::Record::Subdivision.new(s, locales)
+          subdivisions.map do |s|
+            MaxMind::GeoIP2::Record::Subdivision.new(s, locales)
+          end
+        end
       end
     end
   end

--- a/lib/maxmind/geoip2/model/connection_type.rb
+++ b/lib/maxmind/geoip2/model/connection_type.rb
@@ -2,31 +2,35 @@
 
 require 'maxmind/geoip2/model/abstract'
 
-module MaxMind::GeoIP2::Model
-  # Model class for the GeoIP2 Connection Type database.
-  class ConnectionType < Abstract
-    # The connection type may take the following values: "Dialup", "Cable/DSL",
-    # "Corporate", "Cellular". Additional values may be added in the future.
-    #
-    # @return [String, nil]
-    def connection_type
-      get('connection_type')
-    end
+module MaxMind
+  module GeoIP2
+    module Model
+      # Model class for the GeoIP2 Connection Type database.
+      class ConnectionType < Abstract
+        # The connection type may take the following values: "Dialup", "Cable/DSL",
+        # "Corporate", "Cellular". Additional values may be added in the future.
+        #
+        # @return [String, nil]
+        def connection_type
+          get('connection_type')
+        end
 
-    # The IP address that the data in the model is for.
-    #
-    # @return [String]
-    def ip_address
-      get('ip_address')
-    end
+        # The IP address that the data in the model is for.
+        #
+        # @return [String]
+        def ip_address
+          get('ip_address')
+        end
 
-    # The network in CIDR notation associated with the record. In particular,
-    # this is the largest network where all of the fields besides ip_address
-    # have the same value.
-    #
-    # @return [String]
-    def network
-      get('network')
+        # The network in CIDR notation associated with the record. In particular,
+        # this is the largest network where all of the fields besides ip_address
+        # have the same value.
+        #
+        # @return [String]
+        def network
+          get('network')
+        end
+      end
     end
   end
 end

--- a/lib/maxmind/geoip2/model/country.rb
+++ b/lib/maxmind/geoip2/model/country.rb
@@ -6,65 +6,69 @@ require 'maxmind/geoip2/record/maxmind'
 require 'maxmind/geoip2/record/represented_country'
 require 'maxmind/geoip2/record/traits'
 
-module MaxMind::GeoIP2::Model
-  # Model class for the data returned by the GeoIP2 Country web service and
-  # database. It is also used for GeoLite2 Country lookups.
-  class Country
-    # Continent data for the IP address.
-    #
-    # @return [MaxMind::GeoIP2::Record::Continent]
-    attr_reader :continent
+module MaxMind
+  module GeoIP2
+    module Model
+      # Model class for the data returned by the GeoIP2 Country web service and
+      # database. It is also used for GeoLite2 Country lookups.
+      class Country
+        # Continent data for the IP address.
+        #
+        # @return [MaxMind::GeoIP2::Record::Continent]
+        attr_reader :continent
 
-    # Country data for the IP address. This object represents the country where
-    # MaxMind believes the end user is located.
-    #
-    # @return [MaxMind::GeoIP2::Record::Country]
-    attr_reader :country
+        # Country data for the IP address. This object represents the country where
+        # MaxMind believes the end user is located.
+        #
+        # @return [MaxMind::GeoIP2::Record::Country]
+        attr_reader :country
 
-    # Data related to your MaxMind account.
-    #
-    # @return [MaxMind::GeoIP2::Record::MaxMind]
-    attr_reader :maxmind
+        # Data related to your MaxMind account.
+        #
+        # @return [MaxMind::GeoIP2::Record::MaxMind]
+        attr_reader :maxmind
 
-    # Registered country data for the IP address. This record represents the
-    # country where the ISP has registered a given IP block and may differ from
-    # the user's country.
-    #
-    # @return [MaxMind::GeoIP2::Record::Country]
-    attr_reader :registered_country
+        # Registered country data for the IP address. This record represents the
+        # country where the ISP has registered a given IP block and may differ from
+        # the user's country.
+        #
+        # @return [MaxMind::GeoIP2::Record::Country]
+        attr_reader :registered_country
 
-    # Represented country data for the IP address. The represented country is
-    # used for things like military bases. It is only present when the
-    # represented country differs from the country.
-    #
-    # @return [MaxMind::GeoIP2::Record::RepresentedCountry]
-    attr_reader :represented_country
+        # Represented country data for the IP address. The represented country is
+        # used for things like military bases. It is only present when the
+        # represented country differs from the country.
+        #
+        # @return [MaxMind::GeoIP2::Record::RepresentedCountry]
+        attr_reader :represented_country
 
-    # Data for the traits of the IP address.
-    #
-    # @return [MaxMind::GeoIP2::Record::Traits]
-    attr_reader :traits
+        # Data for the traits of the IP address.
+        #
+        # @return [MaxMind::GeoIP2::Record::Traits]
+        attr_reader :traits
 
-    # @!visibility private
-    def initialize(record, locales)
-      @continent = MaxMind::GeoIP2::Record::Continent.new(
-        record['continent'],
-        locales,
-      )
-      @country = MaxMind::GeoIP2::Record::Country.new(
-        record['country'],
-        locales,
-      )
-      @maxmind = MaxMind::GeoIP2::Record::MaxMind.new(record['maxmind'])
-      @registered_country = MaxMind::GeoIP2::Record::Country.new(
-        record['registered_country'],
-        locales,
-      )
-      @represented_country = MaxMind::GeoIP2::Record::RepresentedCountry.new(
-        record['represented_country'],
-        locales,
-      )
-      @traits = MaxMind::GeoIP2::Record::Traits.new(record['traits'])
+        # @!visibility private
+        def initialize(record, locales)
+          @continent = MaxMind::GeoIP2::Record::Continent.new(
+            record['continent'],
+            locales,
+          )
+          @country = MaxMind::GeoIP2::Record::Country.new(
+            record['country'],
+            locales,
+          )
+          @maxmind = MaxMind::GeoIP2::Record::MaxMind.new(record['maxmind'])
+          @registered_country = MaxMind::GeoIP2::Record::Country.new(
+            record['registered_country'],
+            locales,
+          )
+          @represented_country = MaxMind::GeoIP2::Record::RepresentedCountry.new(
+            record['represented_country'],
+            locales,
+          )
+          @traits = MaxMind::GeoIP2::Record::Traits.new(record['traits'])
+        end
+      end
     end
   end
 end

--- a/lib/maxmind/geoip2/model/domain.rb
+++ b/lib/maxmind/geoip2/model/domain.rb
@@ -2,31 +2,35 @@
 
 require 'maxmind/geoip2/model/abstract'
 
-module MaxMind::GeoIP2::Model
-  # Model class for the GeoIP2 Domain database.
-  class Domain < Abstract
-    # The second level domain associated with the IP address. This will be
-    # something like "example.com" or "example.co.uk", not "foo.example.com".
-    #
-    # @return [String, nil]
-    def domain
-      get('domain')
-    end
+module MaxMind
+  module GeoIP2
+    module Model
+      # Model class for the GeoIP2 Domain database.
+      class Domain < Abstract
+        # The second level domain associated with the IP address. This will be
+        # something like "example.com" or "example.co.uk", not "foo.example.com".
+        #
+        # @return [String, nil]
+        def domain
+          get('domain')
+        end
 
-    # The IP address that the data in the model is for.
-    #
-    # @return [String]
-    def ip_address
-      get('ip_address')
-    end
+        # The IP address that the data in the model is for.
+        #
+        # @return [String]
+        def ip_address
+          get('ip_address')
+        end
 
-    # The network in CIDR notation associated with the record. In particular,
-    # this is the largest network where all of the fields besides ip_address
-    # have the same value.
-    #
-    # @return [String]
-    def network
-      get('network')
+        # The network in CIDR notation associated with the record. In particular,
+        # this is the largest network where all of the fields besides ip_address
+        # have the same value.
+        #
+        # @return [String]
+        def network
+          get('network')
+        end
+      end
     end
   end
 end

--- a/lib/maxmind/geoip2/model/enterprise.rb
+++ b/lib/maxmind/geoip2/model/enterprise.rb
@@ -2,14 +2,18 @@
 
 require 'maxmind/geoip2/model/city'
 
-module MaxMind::GeoIP2::Model
-  # Model class for the data returned by GeoIP2 Enterprise database lookups.
-  #
-  # The only difference between the City and Insights model classes is which
-  # fields in each record may be populated. See
-  # https://dev.maxmind.com/geoip/geoip2/web-services for more details.
-  #
-  # See {MaxMind::GeoIP2::Model::City} for inherited methods.
-  class Enterprise < City
+module MaxMind
+  module GeoIP2
+    module Model
+      # Model class for the data returned by GeoIP2 Enterprise database lookups.
+      #
+      # The only difference between the City and Insights model classes is which
+      # fields in each record may be populated. See
+      # https://dev.maxmind.com/geoip/geoip2/web-services for more details.
+      #
+      # See {MaxMind::GeoIP2::Model::City} for inherited methods.
+      class Enterprise < City
+      end
+    end
   end
 end

--- a/lib/maxmind/geoip2/model/insights.rb
+++ b/lib/maxmind/geoip2/model/insights.rb
@@ -2,13 +2,17 @@
 
 require 'maxmind/geoip2/model/city'
 
-module MaxMind::GeoIP2::Model
-  # Model class for the data returned by the GeoIP2 Precision Insights web
-  # service.
-  #
-  # The only difference between the City and Insights model classes is which
-  # fields in each record may be populated. See
-  # https://dev.maxmind.com/geoip/geoip2/web-services for more details.
-  class Insights < City
+module MaxMind
+  module GeoIP2
+    module Model
+      # Model class for the data returned by the GeoIP2 Precision Insights web
+      # service.
+      #
+      # The only difference between the City and Insights model classes is which
+      # fields in each record may be populated. See
+      # https://dev.maxmind.com/geoip/geoip2/web-services for more details.
+      class Insights < City
+      end
+    end
   end
 end

--- a/lib/maxmind/geoip2/model/isp.rb
+++ b/lib/maxmind/geoip2/model/isp.rb
@@ -2,52 +2,56 @@
 
 require 'maxmind/geoip2/model/abstract'
 
-module MaxMind::GeoIP2::Model
-  # Model class for the GeoIP2 ISP database.
-  class ISP < Abstract
-    # The autonomous system number associated with the IP address.
-    #
-    # @return [Integer, nil]
-    def autonomous_system_number
-      get('autonomous_system_number')
-    end
+module MaxMind
+  module GeoIP2
+    module Model
+      # Model class for the GeoIP2 ISP database.
+      class ISP < Abstract
+        # The autonomous system number associated with the IP address.
+        #
+        # @return [Integer, nil]
+        def autonomous_system_number
+          get('autonomous_system_number')
+        end
 
-    # The organization associated with the registered autonomous system number
-    # for the IP address.
-    #
-    # @return [String, nil]
-    def autonomous_system_organization
-      get('autonomous_system_organization')
-    end
+        # The organization associated with the registered autonomous system number
+        # for the IP address.
+        #
+        # @return [String, nil]
+        def autonomous_system_organization
+          get('autonomous_system_organization')
+        end
 
-    # The IP address that the data in the model is for.
-    #
-    # @return [String]
-    def ip_address
-      get('ip_address')
-    end
+        # The IP address that the data in the model is for.
+        #
+        # @return [String]
+        def ip_address
+          get('ip_address')
+        end
 
-    # The name of the ISP associated with the IP address.
-    #
-    # @return [String, nil]
-    def isp
-      get('isp')
-    end
+        # The name of the ISP associated with the IP address.
+        #
+        # @return [String, nil]
+        def isp
+          get('isp')
+        end
 
-    # The network in CIDR notation associated with the record. In particular,
-    # this is the largest network where all of the fields besides ip_address
-    # have the same value.
-    #
-    # @return [String]
-    def network
-      get('network')
-    end
+        # The network in CIDR notation associated with the record. In particular,
+        # this is the largest network where all of the fields besides ip_address
+        # have the same value.
+        #
+        # @return [String]
+        def network
+          get('network')
+        end
 
-    # The name of the organization associated with the IP address.
-    #
-    # @return [String, nil]
-    def organization
-      get('organization')
+        # The name of the organization associated with the IP address.
+        #
+        # @return [String, nil]
+        def organization
+          get('organization')
+        end
+      end
     end
   end
 end

--- a/lib/maxmind/geoip2/reader.rb
+++ b/lib/maxmind/geoip2/reader.rb
@@ -11,267 +11,269 @@ require 'maxmind/geoip2/model/domain'
 require 'maxmind/geoip2/model/enterprise'
 require 'maxmind/geoip2/model/isp'
 
-module MaxMind::GeoIP2
-  # Reader is a reader for the GeoIP2/GeoLite2 database format. IP addresses
-  # can be looked up using the database specific methods.
-  #
-  # == Example
-  #
-  #   require 'maxmind/geoip2'
-  #
-  #   reader = MaxMind::GeoIP2::Reader.new('GeoIP2-Country.mmdb')
-  #
-  #   record = reader.country('1.2.3.4')
-  #   puts record.country.iso_code
-  #
-  #   reader.close
-  class Reader
-    # Create a Reader for looking up IP addresses in a GeoIP2/GeoLite2 database
-    # file.
+module MaxMind
+  module GeoIP2
+    # Reader is a reader for the GeoIP2/GeoLite2 database format. IP addresses
+    # can be looked up using the database specific methods.
     #
-    # If you're performing multiple lookups, it's most efficient to create one
-    # Reader and reuse it.
+    # == Example
     #
-    # Once created, the Reader is safe to use for lookups from multiple
-    # threads. It is safe to use after forking only if you use
-    # MaxMind::DB::MODE_MEMORY or if your version of Ruby supports IO#pread.
+    #   require 'maxmind/geoip2'
     #
-    # @param database [String] a path to a GeoIP2/GeoLite2 database file.
+    #   reader = MaxMind::GeoIP2::Reader.new('GeoIP2-Country.mmdb')
     #
-    # @param locales [Array<String>] a list of locale codes to use in the name
-    #   property from most preferred to least preferred.
+    #   record = reader.country('1.2.3.4')
+    #   puts record.country.iso_code
     #
-    # @param options [Hash<Symbol, Symbol>] options controlling the behavior of
-    #   the Reader.
-    #
-    # @option options [Symbol] :mode Defines how to open the database. It may
-    #   be one of MaxMind::DB::MODE_AUTO, MaxMind::DB::MODE_FILE, or
-    #   MaxMind::DB::MODE_MEMORY. If you don't provide one, the Reader uses
-    #   MaxMind::DB::MODE_AUTO. Refer to the definition of those constants in
-    #   MaxMind::DB for an explanation of their meaning.
-    #
-    # @raise [MaxMind::DB::InvalidDatabaseError] if the database is corrupt or
-    #   invalid.
-    #
-    # @raise [ArgumentError] if the mode is invalid.
-    def initialize(database, locales = ['en'], options = {})
-      @reader = MaxMind::DB.new(database, options)
-      @type = @reader.metadata.database_type
-      locales = ['en'] if locales.empty?
-      @locales = locales
-    end
-
-    # Look up the IP address in the database.
-    #
-    # @param ip_address [String] a string in the standard notation. It may be
-    #   IPv4 or IPv6.
-    #
-    # @return [MaxMind::GeoIP2::Model::AnonymousIP]
-    #
-    # @raise [ArgumentError] if used against a non-Anonymous IP database or if
-    #   you attempt to look up an IPv6 address in an IPv4 only database.
-    #
-    # @raise [AddressNotFoundError] if the IP address is not found in the
-    #   database.
-    #
-    # @raise [MaxMind::DB::InvalidDatabaseError] if the database appears
-    #   corrupt.
-    def anonymous_ip(ip_address)
-      flat_model_for(
-        Model::AnonymousIP,
-        'anonymous_ip',
-        'GeoIP2-Anonymous-IP',
-        ip_address,
-      )
-    end
-
-    # Look up the IP address in an ASN database.
-    #
-    # @param ip_address [String] a string in the standard notation. It may be
-    #   IPv4 or IPv6.
-    #
-    # @return [MaxMind::GeoIP2::Model::ASN]
-    #
-    # @raise [ArgumentError] if used against a non-ASN database or if you
-    #   attempt to look up an IPv6 address in an IPv4 only database.
-    #
-    # @raise [AddressNotFoundError] if the IP address is not found in the
-    #   database.
-    #
-    # @raise [MaxMind::DB::InvalidDatabaseError] if the database appears
-    #   corrupt.
-    def asn(ip_address)
-      flat_model_for(Model::ASN, 'asn', 'GeoLite2-ASN', ip_address)
-    end
-
-    # Look up the IP address in a City database.
-    #
-    # @param ip_address [String] a string in the standard notation. It may be
-    #   IPv4 or IPv6.
-    #
-    # @return [MaxMind::GeoIP2::Model::City]
-    #
-    # @raise [ArgumentError] if used against a non-City database or if you
-    #   attempt to look up an IPv6 address in an IPv4 only database.
-    #
-    # @raise [AddressNotFoundError] if the IP address is not found in the
-    #   database.
-    #
-    # @raise [MaxMind::DB::InvalidDatabaseError] if the database appears
-    #   corrupt.
-    def city(ip_address)
-      model_for(Model::City, 'city', 'City', ip_address)
-    end
-
-    # Look up the IP address in a Connection Type database.
-    #
-    # @param ip_address [String] a string in the standard notation. It may be
-    #   IPv4 or IPv6.
-    #
-    # @return [MaxMind::GeoIP2::Model::ConnectionType]
-    #
-    # @raise [ArgumentError] if used against a non-Connection Type database or if
-    #   you attempt to look up an IPv6 address in an IPv4 only database.
-    #
-    # @raise [AddressNotFoundError] if the IP address is not found in the
-    #   database.
-    #
-    # @raise [MaxMind::DB::InvalidDatabaseError] if the database appears
-    #   corrupt.
-    def connection_type(ip_address)
-      flat_model_for(
-        Model::ConnectionType,
-        'connection_type',
-        'GeoIP2-Connection-Type',
-        ip_address,
-      )
-    end
-
-    # Look up the IP address in a Country database.
-    #
-    # @param ip_address [String] a string in the standard notation. It may be
-    #   IPv4 or IPv6.
-    #
-    # @return [MaxMind::GeoIP2::Model::Country]
-    #
-    # @raise [ArgumentError] if used against a non-Country database or if you
-    #   attempt to look up an IPv6 address in an IPv4 only database.
-    #
-    # @raise [AddressNotFoundError] if the IP address is not found in the
-    #   database.
-    #
-    # @raise [MaxMind::DB::InvalidDatabaseError] if the database appears
-    #   corrupt.
-    def country(ip_address)
-      model_for(Model::Country, 'country', 'Country', ip_address)
-    end
-
-    # Look up the IP address in a Domain database.
-    #
-    # @param ip_address [String] a string in the standard notation. It may be
-    #   IPv4 or IPv6.
-    #
-    # @return [MaxMind::GeoIP2::Model::Domain]
-    #
-    # @raise [ArgumentError] if used against a non-Domain database or if you
-    #   attempt to look up an IPv6 address in an IPv4 only database.
-    #
-    # @raise [AddressNotFoundError] if the IP address is not found in the
-    #   database.
-    #
-    # @raise [MaxMind::DB::InvalidDatabaseError] if the database appears
-    #   corrupt.
-    def domain(ip_address)
-      flat_model_for(Model::Domain, 'domain', 'GeoIP2-Domain', ip_address)
-    end
-
-    # Look up the IP address in an Enterprise database.
-    #
-    # @param ip_address [String] a string in the standard notation. It may be
-    #   IPv4 or IPv6.
-    #
-    # @return [MaxMind::GeoIP2::Model::Enterprise]
-    #
-    # @raise [ArgumentError] if used against a non-Enterprise database or if
-    #   you attempt to look up an IPv6 address in an IPv4 only database.
-    #
-    # @raise [AddressNotFoundError] if the IP address is not found in the
-    #   database.
-    #
-    # @raise [MaxMind::DB::InvalidDatabaseError] if the database appears
-    #   corrupt.
-    def enterprise(ip_address)
-      model_for(Model::Enterprise, 'enterprise', 'Enterprise', ip_address)
-    end
-
-    # Look up the IP address in an ISP database.
-    #
-    # @param ip_address [String] a string in the standard notation. It may be
-    #   IPv4 or IPv6.
-    #
-    # @return [MaxMind::GeoIP2::Model::ISP]
-    #
-    # @raise [ArgumentError] if used against a non-ISP database or if you
-    #   attempt to look up an IPv6 address in an IPv4 only database.
-    #
-    # @raise [AddressNotFoundError] if the IP address is not found in the
-    #   database.
-    #
-    # @raise [MaxMind::DB::InvalidDatabaseError] if the database appears
-    #   corrupt.
-    def isp(ip_address)
-      flat_model_for(Model::ISP, 'isp', 'GeoIP2-ISP', ip_address)
-    end
-
-    # Return the metadata associated with the database.
-    #
-    # @return [MaxMind::DB::Metadata]
-    def metadata
-      @reader.metadata
-    end
-
-    # Close the Reader and return resources to the system.
-    #
-    # @return [void]
-    def close
-      @reader.close
-    end
-
-    private
-
-    def model_for(model_class, method, type, ip_address)
-      record, prefix_length = get_record(method, type, ip_address)
-
-      record['traits'] = {} if !record.key?('traits')
-      record['traits']['ip_address'] = ip_address
-      record['traits']['prefix_length'] = prefix_length
-
-      model_class.new(record, @locales)
-    end
-
-    def get_record(method, type, ip_address)
-      if !@type.include?(type)
-        raise ArgumentError,
-              "The #{method} method cannot be used with the #{@type} database."
+    #   reader.close
+    class Reader
+      # Create a Reader for looking up IP addresses in a GeoIP2/GeoLite2 database
+      # file.
+      #
+      # If you're performing multiple lookups, it's most efficient to create one
+      # Reader and reuse it.
+      #
+      # Once created, the Reader is safe to use for lookups from multiple
+      # threads. It is safe to use after forking only if you use
+      # MaxMind::DB::MODE_MEMORY or if your version of Ruby supports IO#pread.
+      #
+      # @param database [String] a path to a GeoIP2/GeoLite2 database file.
+      #
+      # @param locales [Array<String>] a list of locale codes to use in the name
+      #   property from most preferred to least preferred.
+      #
+      # @param options [Hash<Symbol, Symbol>] options controlling the behavior of
+      #   the Reader.
+      #
+      # @option options [Symbol] :mode Defines how to open the database. It may
+      #   be one of MaxMind::DB::MODE_AUTO, MaxMind::DB::MODE_FILE, or
+      #   MaxMind::DB::MODE_MEMORY. If you don't provide one, the Reader uses
+      #   MaxMind::DB::MODE_AUTO. Refer to the definition of those constants in
+      #   MaxMind::DB for an explanation of their meaning.
+      #
+      # @raise [MaxMind::DB::InvalidDatabaseError] if the database is corrupt or
+      #   invalid.
+      #
+      # @raise [ArgumentError] if the mode is invalid.
+      def initialize(database, locales = ['en'], options = {})
+        @reader = MaxMind::DB.new(database, options)
+        @type = @reader.metadata.database_type
+        locales = ['en'] if locales.empty?
+        @locales = locales
       end
 
-      record, prefix_length = @reader.get_with_prefix_length(ip_address)
-
-      if record.nil?
-        raise AddressNotFoundError,
-              "The address #{ip_address} is not in the database."
+      # Look up the IP address in the database.
+      #
+      # @param ip_address [String] a string in the standard notation. It may be
+      #   IPv4 or IPv6.
+      #
+      # @return [MaxMind::GeoIP2::Model::AnonymousIP]
+      #
+      # @raise [ArgumentError] if used against a non-Anonymous IP database or if
+      #   you attempt to look up an IPv6 address in an IPv4 only database.
+      #
+      # @raise [AddressNotFoundError] if the IP address is not found in the
+      #   database.
+      #
+      # @raise [MaxMind::DB::InvalidDatabaseError] if the database appears
+      #   corrupt.
+      def anonymous_ip(ip_address)
+        flat_model_for(
+          Model::AnonymousIP,
+          'anonymous_ip',
+          'GeoIP2-Anonymous-IP',
+          ip_address,
+        )
       end
 
-      [record, prefix_length]
-    end
+      # Look up the IP address in an ASN database.
+      #
+      # @param ip_address [String] a string in the standard notation. It may be
+      #   IPv4 or IPv6.
+      #
+      # @return [MaxMind::GeoIP2::Model::ASN]
+      #
+      # @raise [ArgumentError] if used against a non-ASN database or if you
+      #   attempt to look up an IPv6 address in an IPv4 only database.
+      #
+      # @raise [AddressNotFoundError] if the IP address is not found in the
+      #   database.
+      #
+      # @raise [MaxMind::DB::InvalidDatabaseError] if the database appears
+      #   corrupt.
+      def asn(ip_address)
+        flat_model_for(Model::ASN, 'asn', 'GeoLite2-ASN', ip_address)
+      end
 
-    def flat_model_for(model_class, method, type, ip_address)
-      record, prefix_length = get_record(method, type, ip_address)
+      # Look up the IP address in a City database.
+      #
+      # @param ip_address [String] a string in the standard notation. It may be
+      #   IPv4 or IPv6.
+      #
+      # @return [MaxMind::GeoIP2::Model::City]
+      #
+      # @raise [ArgumentError] if used against a non-City database or if you
+      #   attempt to look up an IPv6 address in an IPv4 only database.
+      #
+      # @raise [AddressNotFoundError] if the IP address is not found in the
+      #   database.
+      #
+      # @raise [MaxMind::DB::InvalidDatabaseError] if the database appears
+      #   corrupt.
+      def city(ip_address)
+        model_for(Model::City, 'city', 'City', ip_address)
+      end
 
-      record['ip_address'] = ip_address
-      record['prefix_length'] = prefix_length
+      # Look up the IP address in a Connection Type database.
+      #
+      # @param ip_address [String] a string in the standard notation. It may be
+      #   IPv4 or IPv6.
+      #
+      # @return [MaxMind::GeoIP2::Model::ConnectionType]
+      #
+      # @raise [ArgumentError] if used against a non-Connection Type database or if
+      #   you attempt to look up an IPv6 address in an IPv4 only database.
+      #
+      # @raise [AddressNotFoundError] if the IP address is not found in the
+      #   database.
+      #
+      # @raise [MaxMind::DB::InvalidDatabaseError] if the database appears
+      #   corrupt.
+      def connection_type(ip_address)
+        flat_model_for(
+          Model::ConnectionType,
+          'connection_type',
+          'GeoIP2-Connection-Type',
+          ip_address,
+        )
+      end
 
-      model_class.new(record)
+      # Look up the IP address in a Country database.
+      #
+      # @param ip_address [String] a string in the standard notation. It may be
+      #   IPv4 or IPv6.
+      #
+      # @return [MaxMind::GeoIP2::Model::Country]
+      #
+      # @raise [ArgumentError] if used against a non-Country database or if you
+      #   attempt to look up an IPv6 address in an IPv4 only database.
+      #
+      # @raise [AddressNotFoundError] if the IP address is not found in the
+      #   database.
+      #
+      # @raise [MaxMind::DB::InvalidDatabaseError] if the database appears
+      #   corrupt.
+      def country(ip_address)
+        model_for(Model::Country, 'country', 'Country', ip_address)
+      end
+
+      # Look up the IP address in a Domain database.
+      #
+      # @param ip_address [String] a string in the standard notation. It may be
+      #   IPv4 or IPv6.
+      #
+      # @return [MaxMind::GeoIP2::Model::Domain]
+      #
+      # @raise [ArgumentError] if used against a non-Domain database or if you
+      #   attempt to look up an IPv6 address in an IPv4 only database.
+      #
+      # @raise [AddressNotFoundError] if the IP address is not found in the
+      #   database.
+      #
+      # @raise [MaxMind::DB::InvalidDatabaseError] if the database appears
+      #   corrupt.
+      def domain(ip_address)
+        flat_model_for(Model::Domain, 'domain', 'GeoIP2-Domain', ip_address)
+      end
+
+      # Look up the IP address in an Enterprise database.
+      #
+      # @param ip_address [String] a string in the standard notation. It may be
+      #   IPv4 or IPv6.
+      #
+      # @return [MaxMind::GeoIP2::Model::Enterprise]
+      #
+      # @raise [ArgumentError] if used against a non-Enterprise database or if
+      #   you attempt to look up an IPv6 address in an IPv4 only database.
+      #
+      # @raise [AddressNotFoundError] if the IP address is not found in the
+      #   database.
+      #
+      # @raise [MaxMind::DB::InvalidDatabaseError] if the database appears
+      #   corrupt.
+      def enterprise(ip_address)
+        model_for(Model::Enterprise, 'enterprise', 'Enterprise', ip_address)
+      end
+
+      # Look up the IP address in an ISP database.
+      #
+      # @param ip_address [String] a string in the standard notation. It may be
+      #   IPv4 or IPv6.
+      #
+      # @return [MaxMind::GeoIP2::Model::ISP]
+      #
+      # @raise [ArgumentError] if used against a non-ISP database or if you
+      #   attempt to look up an IPv6 address in an IPv4 only database.
+      #
+      # @raise [AddressNotFoundError] if the IP address is not found in the
+      #   database.
+      #
+      # @raise [MaxMind::DB::InvalidDatabaseError] if the database appears
+      #   corrupt.
+      def isp(ip_address)
+        flat_model_for(Model::ISP, 'isp', 'GeoIP2-ISP', ip_address)
+      end
+
+      # Return the metadata associated with the database.
+      #
+      # @return [MaxMind::DB::Metadata]
+      def metadata
+        @reader.metadata
+      end
+
+      # Close the Reader and return resources to the system.
+      #
+      # @return [void]
+      def close
+        @reader.close
+      end
+
+      private
+
+      def model_for(model_class, method, type, ip_address)
+        record, prefix_length = get_record(method, type, ip_address)
+
+        record['traits'] = {} if !record.key?('traits')
+        record['traits']['ip_address'] = ip_address
+        record['traits']['prefix_length'] = prefix_length
+
+        model_class.new(record, @locales)
+      end
+
+      def get_record(method, type, ip_address)
+        if !@type.include?(type)
+          raise ArgumentError,
+                "The #{method} method cannot be used with the #{@type} database."
+        end
+
+        record, prefix_length = @reader.get_with_prefix_length(ip_address)
+
+        if record.nil?
+          raise AddressNotFoundError,
+                "The address #{ip_address} is not in the database."
+        end
+
+        [record, prefix_length]
+      end
+
+      def flat_model_for(model_class, method, type, ip_address)
+        record, prefix_length = get_record(method, type, ip_address)
+
+        record['ip_address'] = ip_address
+        record['prefix_length'] = prefix_length
+
+        model_class.new(record)
+      end
     end
   end
 end

--- a/lib/maxmind/geoip2/record/abstract.rb
+++ b/lib/maxmind/geoip2/record/abstract.rb
@@ -1,22 +1,26 @@
 # frozen_string_literal: true
 
-module MaxMind::GeoIP2::Record
-  # @!visibility private
-  class Abstract
-    def initialize(record)
-      @record = record
-    end
+module MaxMind
+  module GeoIP2
+    module Record
+      # @!visibility private
+      class Abstract
+        def initialize(record)
+          @record = record
+        end
 
-    protected
+        protected
 
-    def get(key)
-      if @record.nil? || !@record.key?(key)
-        return false if key.start_with?('is_')
+        def get(key)
+          if @record.nil? || !@record.key?(key)
+            return false if key.start_with?('is_')
 
-        return nil
+            return nil
+          end
+
+          @record[key]
+        end
       end
-
-      @record[key]
     end
   end
 end

--- a/lib/maxmind/geoip2/record/city.rb
+++ b/lib/maxmind/geoip2/record/city.rb
@@ -2,37 +2,41 @@
 
 require 'maxmind/geoip2/record/place'
 
-module MaxMind::GeoIP2::Record
-  # City-level data associated with an IP address.
-  #
-  # This record is returned by all location services and databases besides
-  # Country.
-  #
-  # See {MaxMind::GeoIP2::Record::Place} for inherited methods.
-  class City < Place
-    # A value from 0-100 indicating MaxMind's confidence that the city is
-    # correct. This attribute is only available from the Insights service and
-    # the GeoIP2 Enterprise database.
-    #
-    # @return [Integer, nil]
-    def confidence
-      get('confidence')
-    end
+module MaxMind
+  module GeoIP2
+    module Record
+      # City-level data associated with an IP address.
+      #
+      # This record is returned by all location services and databases besides
+      # Country.
+      #
+      # See {MaxMind::GeoIP2::Record::Place} for inherited methods.
+      class City < Place
+        # A value from 0-100 indicating MaxMind's confidence that the city is
+        # correct. This attribute is only available from the Insights service and
+        # the GeoIP2 Enterprise database.
+        #
+        # @return [Integer, nil]
+        def confidence
+          get('confidence')
+        end
 
-    # The GeoName ID for the city. This attribute is returned by all location
-    # services and databases.
-    #
-    # @return [Integer, nil]
-    def geoname_id
-      get('geoname_id')
-    end
+        # The GeoName ID for the city. This attribute is returned by all location
+        # services and databases.
+        #
+        # @return [Integer, nil]
+        def geoname_id
+          get('geoname_id')
+        end
 
-    # A Hash where the keys are locale codes and the values are names. This
-    # attribute is returned by all location services and databases.
-    #
-    # @return [Hash<String, String>, nil]
-    def names
-      get('names')
+        # A Hash where the keys are locale codes and the values are names. This
+        # attribute is returned by all location services and databases.
+        #
+        # @return [Hash<String, String>, nil]
+        def names
+          get('names')
+        end
+      end
     end
   end
 end

--- a/lib/maxmind/geoip2/record/continent.rb
+++ b/lib/maxmind/geoip2/record/continent.rb
@@ -2,36 +2,40 @@
 
 require 'maxmind/geoip2/record/place'
 
-module MaxMind::GeoIP2::Record
-  # Contains data for the continent record associated with an IP address.
-  #
-  # This record is returned by all location services and databases.
-  #
-  # See {MaxMind::GeoIP2::Record::Place} for inherited methods.
-  class Continent < Place
-    # A two character continent code like "NA" (North America) or "OC"
-    # (Oceania). This attribute is returned by all location services and
-    # databases.
-    #
-    # @return [String, nil]
-    def code
-      get('code')
-    end
+module MaxMind
+  module GeoIP2
+    module Record
+      # Contains data for the continent record associated with an IP address.
+      #
+      # This record is returned by all location services and databases.
+      #
+      # See {MaxMind::GeoIP2::Record::Place} for inherited methods.
+      class Continent < Place
+        # A two character continent code like "NA" (North America) or "OC"
+        # (Oceania). This attribute is returned by all location services and
+        # databases.
+        #
+        # @return [String, nil]
+        def code
+          get('code')
+        end
 
-    # The GeoName ID for the continent. This attribute is returned by all
-    # location services and databases.
-    #
-    # @return [String, nil]
-    def geoname_id
-      get('geoname_id')
-    end
+        # The GeoName ID for the continent. This attribute is returned by all
+        # location services and databases.
+        #
+        # @return [String, nil]
+        def geoname_id
+          get('geoname_id')
+        end
 
-    # A Hash where the keys are locale codes and the values are names. This
-    # attribute is returned by all location services and databases.
-    #
-    # @return [Hash<String, String>, nil]
-    def names
-      get('names')
+        # A Hash where the keys are locale codes and the values are names. This
+        # attribute is returned by all location services and databases.
+        #
+        # @return [Hash<String, String>, nil]
+        def names
+          get('names')
+        end
+      end
     end
   end
 end

--- a/lib/maxmind/geoip2/record/country.rb
+++ b/lib/maxmind/geoip2/record/country.rb
@@ -2,53 +2,57 @@
 
 require 'maxmind/geoip2/record/place'
 
-module MaxMind::GeoIP2::Record
-  # Contains data for the country record associated with an IP address.
-  #
-  # This record is returned by all location services and databases.
-  #
-  # See {MaxMind::GeoIP2::Record::Place} for inherited methods.
-  class Country < Place
-    # A value from 0-100 indicating MaxMind's confidence that the country is
-    # correct. This attribute is only available from the Insights service and
-    # the GeoIP2 Enterprise database.
-    #
-    # @return [Integer, nil]
-    def confidence
-      get('confidence')
-    end
+module MaxMind
+  module GeoIP2
+    module Record
+      # Contains data for the country record associated with an IP address.
+      #
+      # This record is returned by all location services and databases.
+      #
+      # See {MaxMind::GeoIP2::Record::Place} for inherited methods.
+      class Country < Place
+        # A value from 0-100 indicating MaxMind's confidence that the country is
+        # correct. This attribute is only available from the Insights service and
+        # the GeoIP2 Enterprise database.
+        #
+        # @return [Integer, nil]
+        def confidence
+          get('confidence')
+        end
 
-    # The GeoName ID for the country. This attribute is returned by all
-    # location services and databases.
-    #
-    # @return [Integer, nil]
-    def geoname_id
-      get('geoname_id')
-    end
+        # The GeoName ID for the country. This attribute is returned by all
+        # location services and databases.
+        #
+        # @return [Integer, nil]
+        def geoname_id
+          get('geoname_id')
+        end
 
-    # This is true if the country is a member state of the European Union. This
-    # attribute is returned by all location services and databases.
-    #
-    # @return [Boolean]
-    def in_european_union?
-      get('is_in_european_union')
-    end
+        # This is true if the country is a member state of the European Union. This
+        # attribute is returned by all location services and databases.
+        #
+        # @return [Boolean]
+        def in_european_union?
+          get('is_in_european_union')
+        end
 
-    # The two-character ISO 3166-1 alpha code for the country. See
-    # https://en.wikipedia.org/wiki/ISO_3166-1. This attribute is returned by
-    # all location services and databases.
-    #
-    # @return [String, nil]
-    def iso_code
-      get('iso_code')
-    end
+        # The two-character ISO 3166-1 alpha code for the country. See
+        # https://en.wikipedia.org/wiki/ISO_3166-1. This attribute is returned by
+        # all location services and databases.
+        #
+        # @return [String, nil]
+        def iso_code
+          get('iso_code')
+        end
 
-    # A Hash where the keys are locale codes and the values are names. This
-    # attribute is returned by all location services and databases.
-    #
-    # @return [Hash<String, String>, nil]
-    def names
-      get('names')
+        # A Hash where the keys are locale codes and the values are names. This
+        # attribute is returned by all location services and databases.
+        #
+        # @return [Hash<String, String>, nil]
+        def names
+          get('names')
+        end
+      end
     end
   end
 end

--- a/lib/maxmind/geoip2/record/location.rb
+++ b/lib/maxmind/geoip2/record/location.rb
@@ -2,72 +2,76 @@
 
 require 'maxmind/geoip2/record/abstract'
 
-module MaxMind::GeoIP2::Record
-  # Contains data for the location record associated with an IP address.
-  #
-  # This record is returned by all location services and databases besides
-  # Country.
-  class Location < Abstract
-    # The approximate accuracy radius in kilometers around the latitude and
-    # longitude for the IP address. This is the radius where we have a 67%
-    # confidence that the device using the IP address resides within the circle
-    # centered at the latitude and longitude with the provided radius.
-    #
-    # @return [Integer, nil]
-    def accuracy_radius
-      get('accuracy_radius')
-    end
+module MaxMind
+  module GeoIP2
+    module Record
+      # Contains data for the location record associated with an IP address.
+      #
+      # This record is returned by all location services and databases besides
+      # Country.
+      class Location < Abstract
+        # The approximate accuracy radius in kilometers around the latitude and
+        # longitude for the IP address. This is the radius where we have a 67%
+        # confidence that the device using the IP address resides within the circle
+        # centered at the latitude and longitude with the provided radius.
+        #
+        # @return [Integer, nil]
+        def accuracy_radius
+          get('accuracy_radius')
+        end
 
-    # The average income in US dollars associated with the requested IP
-    # address. This attribute is only available from the Insights service.
-    #
-    # @return [Integer, nil]
-    def average_income
-      get('average_income')
-    end
+        # The average income in US dollars associated with the requested IP
+        # address. This attribute is only available from the Insights service.
+        #
+        # @return [Integer, nil]
+        def average_income
+          get('average_income')
+        end
 
-    # The approximate latitude of the location associated with the IP address.
-    # This value is not precise and should not be used to identify a particular
-    # address or household.
-    #
-    # @return [Float, nil]
-    def latitude
-      get('latitude')
-    end
+        # The approximate latitude of the location associated with the IP address.
+        # This value is not precise and should not be used to identify a particular
+        # address or household.
+        #
+        # @return [Float, nil]
+        def latitude
+          get('latitude')
+        end
 
-    # The approximate longitude of the location associated with the IP address.
-    # This value is not precise and should not be used to identify a particular
-    # address or household.
-    #
-    # @return [Float, nil]
-    def longitude
-      get('longitude')
-    end
+        # The approximate longitude of the location associated with the IP address.
+        # This value is not precise and should not be used to identify a particular
+        # address or household.
+        #
+        # @return [Float, nil]
+        def longitude
+          get('longitude')
+        end
 
-    # The metro code of the location if the location is in the US. MaxMind
-    # returns the same metro codes as the Google AdWords API. See
-    # https://developers.google.com/adwords/api/docs/appendix/cities-DMAregions.
-    #
-    # @return [Integer, nil]
-    def metro_code
-      get('metro_code')
-    end
+        # The metro code of the location if the location is in the US. MaxMind
+        # returns the same metro codes as the Google AdWords API. See
+        # https://developers.google.com/adwords/api/docs/appendix/cities-DMAregions.
+        #
+        # @return [Integer, nil]
+        def metro_code
+          get('metro_code')
+        end
 
-    # The estimated population per square kilometer associated with the IP
-    # address. This attribute is only available from the Insights service.
-    #
-    # @return [Integer, nil]
-    def population_density
-      get('population_density')
-    end
+        # The estimated population per square kilometer associated with the IP
+        # address. This attribute is only available from the Insights service.
+        #
+        # @return [Integer, nil]
+        def population_density
+          get('population_density')
+        end
 
-    # The time zone associated with location, as specified by the IANA Time
-    # Zone Database, e.g., "America/New_York". See
-    # https://www.iana.org/time-zones.
-    #
-    # @return [String, nil]
-    def time_zone
-      get('time_zone')
+        # The time zone associated with location, as specified by the IANA Time
+        # Zone Database, e.g., "America/New_York". See
+        # https://www.iana.org/time-zones.
+        #
+        # @return [String, nil]
+        def time_zone
+          get('time_zone')
+        end
+      end
     end
   end
 end

--- a/lib/maxmind/geoip2/record/maxmind.rb
+++ b/lib/maxmind/geoip2/record/maxmind.rb
@@ -2,16 +2,20 @@
 
 require 'maxmind/geoip2/record/abstract'
 
-module MaxMind::GeoIP2::Record
-  # Contains data about your account.
-  #
-  # This record is returned by all location services.
-  class MaxMind < Abstract
-    # The number of remaining queries you have for the service you are calling.
-    #
-    # @return [Integer, nil]
-    def queries_remaining
-      get('queries_remaining')
+module MaxMind
+  module GeoIP2
+    module Record
+      # Contains data about your account.
+      #
+      # This record is returned by all location services.
+      class MaxMind < Abstract
+        # The number of remaining queries you have for the service you are calling.
+        #
+        # @return [Integer, nil]
+        def queries_remaining
+          get('queries_remaining')
+        end
+      end
     end
   end
 end

--- a/lib/maxmind/geoip2/record/place.rb
+++ b/lib/maxmind/geoip2/record/place.rb
@@ -2,27 +2,31 @@
 
 require 'maxmind/geoip2/record/abstract'
 
-module MaxMind::GeoIP2::Record
-  # Location data common to different location types.
-  class Place < Abstract
-    # @!visibility private
-    def initialize(record, locales)
-      super(record)
-      @locales = locales
-    end
+module MaxMind
+  module GeoIP2
+    module Record
+      # Location data common to different location types.
+      class Place < Abstract
+        # @!visibility private
+        def initialize(record, locales)
+          super(record)
+          @locales = locales
+        end
 
-    # The first available localized name in order of preference.
-    #
-    # @return [String, nil]
-    def name
-      n = names
-      return nil if n.nil?
+        # The first available localized name in order of preference.
+        #
+        # @return [String, nil]
+        def name
+          n = names
+          return nil if n.nil?
 
-      @locales.each do |locale|
-        return n[locale] if n.key?(locale)
+          @locales.each do |locale|
+            return n[locale] if n.key?(locale)
+          end
+
+          nil
+        end
       end
-
-      nil
     end
   end
 end

--- a/lib/maxmind/geoip2/record/postal.rb
+++ b/lib/maxmind/geoip2/record/postal.rb
@@ -2,29 +2,33 @@
 
 require 'maxmind/geoip2/record/abstract'
 
-module MaxMind::GeoIP2::Record
-  # Contains data for the postal record associated with an IP address.
-  #
-  # This record is returned by all location services and databases besides
-  # Country.
-  class Postal < Abstract
-    # The postal code of the location. Postal codes are not available for all
-    # countries. In some countries, this will only contain part of the postal
-    # code. This attribute is returned by all location databases and services
-    # besides Country.
-    #
-    # @return [String, nil]
-    def code
-      get('code')
-    end
+module MaxMind
+  module GeoIP2
+    module Record
+      # Contains data for the postal record associated with an IP address.
+      #
+      # This record is returned by all location services and databases besides
+      # Country.
+      class Postal < Abstract
+        # The postal code of the location. Postal codes are not available for all
+        # countries. In some countries, this will only contain part of the postal
+        # code. This attribute is returned by all location databases and services
+        # besides Country.
+        #
+        # @return [String, nil]
+        def code
+          get('code')
+        end
 
-    # A value from 0-100 indicating MaxMind's confidence that the postal code
-    # is correct. This attribute is only available from the Insights service
-    # and the GeoIP2 Enterprise database.
-    #
-    # @return [Integer, nil]
-    def confidence
-      get('confidence')
+        # A value from 0-100 indicating MaxMind's confidence that the postal code
+        # is correct. This attribute is only available from the Insights service
+        # and the GeoIP2 Enterprise database.
+        #
+        # @return [Integer, nil]
+        def confidence
+          get('confidence')
+        end
+      end
     end
   end
 end

--- a/lib/maxmind/geoip2/record/represented_country.rb
+++ b/lib/maxmind/geoip2/record/represented_country.rb
@@ -2,22 +2,26 @@
 
 require 'maxmind/geoip2/record/country'
 
-module MaxMind::GeoIP2::Record
-  # Contains data for the represented country associated with an IP address.
-  #
-  # This class contains the country-level data associated with an IP address
-  # for the IP's represented country. The represented country is the country
-  # represented by something like a military base.
-  #
-  # See {MaxMind::GeoIP2::Record::Country} for inherited methods.
-  class RepresentedCountry < Country
-    # A string indicating the type of entity that is representing the country.
-    # Currently we only return +military+ but this could expand to include
-    # other types in the future.
-    #
-    # @return [String, nil]
-    def type
-      get('type')
+module MaxMind
+  module GeoIP2
+    module Record
+      # Contains data for the represented country associated with an IP address.
+      #
+      # This class contains the country-level data associated with an IP address
+      # for the IP's represented country. The represented country is the country
+      # represented by something like a military base.
+      #
+      # See {MaxMind::GeoIP2::Record::Country} for inherited methods.
+      class RepresentedCountry < Country
+        # A string indicating the type of entity that is representing the country.
+        # Currently we only return +military+ but this could expand to include
+        # other types in the future.
+        #
+        # @return [String, nil]
+        def type
+          get('type')
+        end
+      end
     end
   end
 end

--- a/lib/maxmind/geoip2/record/subdivision.rb
+++ b/lib/maxmind/geoip2/record/subdivision.rb
@@ -2,47 +2,51 @@
 
 require 'maxmind/geoip2/record/place'
 
-module MaxMind::GeoIP2::Record
-  # Contains data for the subdivisions associated with an IP address.
-  #
-  # This record is returned by all location databases and services besides
-  # Country.
-  #
-  # See {MaxMind::GeoIP2::Record::Place} for inherited methods.
-  class Subdivision < Place
-    # This is a value from 0-100 indicating MaxMind's confidence that the
-    # subdivision is correct. This attribute is only available from the
-    # Insights service and the GeoIP2 Enterprise database.
-    #
-    # @return [Integer, nil]
-    def confidence
-      get('confidence')
-    end
+module MaxMind
+  module GeoIP2
+    module Record
+      # Contains data for the subdivisions associated with an IP address.
+      #
+      # This record is returned by all location databases and services besides
+      # Country.
+      #
+      # See {MaxMind::GeoIP2::Record::Place} for inherited methods.
+      class Subdivision < Place
+        # This is a value from 0-100 indicating MaxMind's confidence that the
+        # subdivision is correct. This attribute is only available from the
+        # Insights service and the GeoIP2 Enterprise database.
+        #
+        # @return [Integer, nil]
+        def confidence
+          get('confidence')
+        end
 
-    # This is a GeoName ID for the subdivision. This attribute is returned by
-    # all location databases and services besides Country.
-    #
-    # @return [Integer, nil]
-    def geoname_id
-      get('geoname_id')
-    end
+        # This is a GeoName ID for the subdivision. This attribute is returned by
+        # all location databases and services besides Country.
+        #
+        # @return [Integer, nil]
+        def geoname_id
+          get('geoname_id')
+        end
 
-    # This is a string up to three characters long contain the subdivision
-    # portion of the ISO 3166-2 code. See
-    # https://en.wikipedia.org/wiki/ISO_3166-2. This attribute is returned by
-    # all location databases and services except Country.
-    #
-    # @return [String, nil]
-    def iso_code
-      get('iso_code')
-    end
+        # This is a string up to three characters long contain the subdivision
+        # portion of the ISO 3166-2 code. See
+        # https://en.wikipedia.org/wiki/ISO_3166-2. This attribute is returned by
+        # all location databases and services except Country.
+        #
+        # @return [String, nil]
+        def iso_code
+          get('iso_code')
+        end
 
-    # A Hash where the keys are locale codes and the values are names. This attribute is returned by all location services and
-    # databases besides country.
-    #
-    # @return [Hash<String, String>, nil]
-    def names
-      get('names')
+        # A Hash where the keys are locale codes and the values are names. This attribute is returned by all location services and
+        # databases besides country.
+        #
+        # @return [Hash<String, String>, nil]
+        def names
+          get('names')
+        end
+      end
     end
   end
 end

--- a/lib/maxmind/geoip2/record/traits.rb
+++ b/lib/maxmind/geoip2/record/traits.rb
@@ -3,198 +3,202 @@
 require 'ipaddr'
 require 'maxmind/geoip2/record/abstract'
 
-module MaxMind::GeoIP2::Record
-  # Contains data for the traits record associated with an IP address.
-  #
-  # This record is returned by all location services and databases.
-  class Traits < Abstract
-    # @!visibility private
-    def initialize(record)
-      super(record)
-      if !record.key?('network') && record.key?('ip_address') &&
-         record.key?('prefix_length')
-        ip = IPAddr.new(record['ip_address']).mask(record['prefix_length'])
-        # We could use ip.prefix instead of record['prefix_length'], but that
-        # method only becomes available in Ruby 2.5+.
-        record['network'] = format('%s/%d', ip.to_s, record['prefix_length'])
+module MaxMind
+  module GeoIP2
+    module Record
+      # Contains data for the traits record associated with an IP address.
+      #
+      # This record is returned by all location services and databases.
+      class Traits < Abstract
+        # @!visibility private
+        def initialize(record)
+          super(record)
+          if !record.key?('network') && record.key?('ip_address') &&
+             record.key?('prefix_length')
+            ip = IPAddr.new(record['ip_address']).mask(record['prefix_length'])
+            # We could use ip.prefix instead of record['prefix_length'], but that
+            # method only becomes available in Ruby 2.5+.
+            record['network'] = format('%s/%d', ip.to_s, record['prefix_length'])
+          end
+        end
+
+        # The autonomous system number associated with the IP address. See
+        # Wikipedia[https://en.wikipedia.org/wiki/Autonomous_system_(Internet)].
+        # This attribute is only available from the City and Insights web service
+        # and the GeoIP2 Enterprise database.
+        #
+        # @return [Integer, nil]
+        def autonomous_system_number
+          get('autonomous_system_number')
+        end
+
+        # The organization associated with the registered autonomous system number
+        # for the IP address. See
+        # Wikipedia[https://en.wikipedia.org/wiki/Autonomous_system_(Internet)].
+        # This attribute is only available from the City and Insights web service
+        # and the GeoIP2 Enterprise database.
+        #
+        # @return [String, nil]
+        def autonomous_system_organization
+          get('autonomous_system_organization')
+        end
+
+        # The connection type may take the following  values: "Dialup",
+        # "Cable/DSL", "Corporate", "Cellular". Additional values may be added in
+        # the future. This attribute is only available in the GeoIP2 Enterprise
+        # database.
+        #
+        # @return [String, nil]
+        def connection_type
+          get('connection_type')
+        end
+
+        # The second level domain associated with the IP address. This will be
+        # something like "example.com" or "example.co.uk", not "foo.example.com".
+        # This attribute is only available from the City and Insights web service
+        # and the GeoIP2 Enterprise database.
+        #
+        # @return [String, nil]
+        def domain
+          get('domain')
+        end
+
+        # The IP address that the data in the model is for. If you performed a "me"
+        # lookup against the web service, this will be the externally routable IP
+        # address for the system the code is running on. If the system is behind a
+        # NAT, this may differ from the IP address locally assigned to it. This
+        # attribute is returned by all end points.
+        #
+        # @return [String]
+        def ip_address
+          get('ip_address')
+        end
+
+        # This is true if the IP address belongs to any sort of anonymous network.
+        # This property is only available from GeoIP2 Precision Insights.
+        #
+        # @return [Boolean]
+        def anonymous?
+          get('is_anonymous')
+        end
+
+        # This is true if the IP address is registered to an anonymous VPN
+        # provider. If a VPN provider does not register subnets under names
+        # associated with them, we will likely only flag their IP ranges using the
+        # hosting_provider? property. This property is only available from GeoIP2
+        # Precision Insights.
+        #
+        # @return [Boolean]
+        def anonymous_vpn?
+          get('is_anonymous_vpn')
+        end
+
+        # This is true if the IP address belongs to a hosting or VPN provider (see
+        # description of the anonymous_vpn? property). This property is only
+        # available from GeoIP2 Precision Insights.
+        #
+        # @return [Boolean]
+        def hosting_provider?
+          get('is_hosting_provider')
+        end
+
+        # This attribute is true if MaxMind believes this IP address to be a
+        # legitimate proxy, such as an internal VPN used by a corporation. This
+        # attribute is only available in the GeoIP2 Enterprise database.
+        #
+        # @return [Boolean]
+        def legitimate_proxy?
+          get('is_legitimate_proxy')
+        end
+
+        # This is true if the IP address belongs to a public proxy. This property
+        # is only available from GeoIP2 Precision Insights.
+        #
+        # @return [Boolean]
+        def public_proxy?
+          get('is_public_proxy')
+        end
+
+        # This is true if the IP address is a Tor exit node. This property is only
+        # available from GeoIP2 Precision Insights.
+        #
+        # @return [Boolean]
+        def tor_exit_node?
+          get('is_tor_exit_node')
+        end
+
+        # The name of the ISP associated with the IP address. This attribute is
+        # only available from the City and Insights web services and the GeoIP2
+        # Enterprise database.
+        #
+        # @return [String, nil]
+        def isp
+          get('isp')
+        end
+
+        # The network in CIDR notation associated with the record. In particular,
+        # this is the largest network where all of the fields besides ip_address
+        # have the same value.
+        #
+        # @return [String]
+        def network
+          get('network')
+        end
+
+        # The name of the organization associated with the IP address. This
+        # attribute is only available from the City and Insights web services and
+        # the GeoIP2 Enterprise database.
+        #
+        # @return [String, nil]
+        def organization
+          get('organization')
+        end
+
+        # An indicator of how static or dynamic an IP address is. This property is
+        # only available from GeoIP2 Precision Insights.
+        #
+        # @return [Float, nil]
+        def static_ip_score
+          get('static_ip_score')
+        end
+
+        # The estimated number of users sharing the IP/network during the past 24
+        # hours. For IPv4, the count is for the individual IP. For IPv6, the count
+        # is for the /64 network. This property is only available from GeoIP2
+        # Precision Insights.
+        #
+        # @return [Integer, nil]
+        def user_count
+          get('user_count')
+        end
+
+        # The user type associated with the IP address. This can be one of the
+        # following values:
+        #
+        # * business
+        # * cafe
+        # * cellular
+        # * college
+        # * content_delivery_network
+        # * dialup
+        # * government
+        # * hosting
+        # * library
+        # * military
+        # * residential
+        # * router
+        # * school
+        # * search_engine_spider
+        # * traveler
+        #
+        # This attribute is only available from the Insights web service and the
+        # GeoIP2 Enterprise database.
+        #
+        # @return [String, nil]
+        def user_type
+          get('user_type')
+        end
       end
-    end
-
-    # The autonomous system number associated with the IP address. See
-    # Wikipedia[https://en.wikipedia.org/wiki/Autonomous_system_(Internet)].
-    # This attribute is only available from the City and Insights web service
-    # and the GeoIP2 Enterprise database.
-    #
-    # @return [Integer, nil]
-    def autonomous_system_number
-      get('autonomous_system_number')
-    end
-
-    # The organization associated with the registered autonomous system number
-    # for the IP address. See
-    # Wikipedia[https://en.wikipedia.org/wiki/Autonomous_system_(Internet)].
-    # This attribute is only available from the City and Insights web service
-    # and the GeoIP2 Enterprise database.
-    #
-    # @return [String, nil]
-    def autonomous_system_organization
-      get('autonomous_system_organization')
-    end
-
-    # The connection type may take the following  values: "Dialup",
-    # "Cable/DSL", "Corporate", "Cellular". Additional values may be added in
-    # the future. This attribute is only available in the GeoIP2 Enterprise
-    # database.
-    #
-    # @return [String, nil]
-    def connection_type
-      get('connection_type')
-    end
-
-    # The second level domain associated with the IP address. This will be
-    # something like "example.com" or "example.co.uk", not "foo.example.com".
-    # This attribute is only available from the City and Insights web service
-    # and the GeoIP2 Enterprise database.
-    #
-    # @return [String, nil]
-    def domain
-      get('domain')
-    end
-
-    # The IP address that the data in the model is for. If you performed a "me"
-    # lookup against the web service, this will be the externally routable IP
-    # address for the system the code is running on. If the system is behind a
-    # NAT, this may differ from the IP address locally assigned to it. This
-    # attribute is returned by all end points.
-    #
-    # @return [String]
-    def ip_address
-      get('ip_address')
-    end
-
-    # This is true if the IP address belongs to any sort of anonymous network.
-    # This property is only available from GeoIP2 Precision Insights.
-    #
-    # @return [Boolean]
-    def anonymous?
-      get('is_anonymous')
-    end
-
-    # This is true if the IP address is registered to an anonymous VPN
-    # provider. If a VPN provider does not register subnets under names
-    # associated with them, we will likely only flag their IP ranges using the
-    # hosting_provider? property. This property is only available from GeoIP2
-    # Precision Insights.
-    #
-    # @return [Boolean]
-    def anonymous_vpn?
-      get('is_anonymous_vpn')
-    end
-
-    # This is true if the IP address belongs to a hosting or VPN provider (see
-    # description of the anonymous_vpn? property). This property is only
-    # available from GeoIP2 Precision Insights.
-    #
-    # @return [Boolean]
-    def hosting_provider?
-      get('is_hosting_provider')
-    end
-
-    # This attribute is true if MaxMind believes this IP address to be a
-    # legitimate proxy, such as an internal VPN used by a corporation. This
-    # attribute is only available in the GeoIP2 Enterprise database.
-    #
-    # @return [Boolean]
-    def legitimate_proxy?
-      get('is_legitimate_proxy')
-    end
-
-    # This is true if the IP address belongs to a public proxy. This property
-    # is only available from GeoIP2 Precision Insights.
-    #
-    # @return [Boolean]
-    def public_proxy?
-      get('is_public_proxy')
-    end
-
-    # This is true if the IP address is a Tor exit node. This property is only
-    # available from GeoIP2 Precision Insights.
-    #
-    # @return [Boolean]
-    def tor_exit_node?
-      get('is_tor_exit_node')
-    end
-
-    # The name of the ISP associated with the IP address. This attribute is
-    # only available from the City and Insights web services and the GeoIP2
-    # Enterprise database.
-    #
-    # @return [String, nil]
-    def isp
-      get('isp')
-    end
-
-    # The network in CIDR notation associated with the record. In particular,
-    # this is the largest network where all of the fields besides ip_address
-    # have the same value.
-    #
-    # @return [String]
-    def network
-      get('network')
-    end
-
-    # The name of the organization associated with the IP address. This
-    # attribute is only available from the City and Insights web services and
-    # the GeoIP2 Enterprise database.
-    #
-    # @return [String, nil]
-    def organization
-      get('organization')
-    end
-
-    # An indicator of how static or dynamic an IP address is. This property is
-    # only available from GeoIP2 Precision Insights.
-    #
-    # @return [Float, nil]
-    def static_ip_score
-      get('static_ip_score')
-    end
-
-    # The estimated number of users sharing the IP/network during the past 24
-    # hours. For IPv4, the count is for the individual IP. For IPv6, the count
-    # is for the /64 network. This property is only available from GeoIP2
-    # Precision Insights.
-    #
-    # @return [Integer, nil]
-    def user_count
-      get('user_count')
-    end
-
-    # The user type associated with the IP address. This can be one of the
-    # following values:
-    #
-    # * business
-    # * cafe
-    # * cellular
-    # * college
-    # * content_delivery_network
-    # * dialup
-    # * government
-    # * hosting
-    # * library
-    # * military
-    # * residential
-    # * router
-    # * school
-    # * search_engine_spider
-    # * traveler
-    #
-    # This attribute is only available from the Insights web service and the
-    # GeoIP2 Enterprise database.
-    #
-    # @return [String, nil]
-    def user_type
-      get('user_type')
     end
   end
 end


### PR DESCRIPTION
The shorthand syntax meant the modules higher in the hierarchy wouldn't
be defined, which is an error. This meant attempting to use the classes
by themselves was not possible unless caller code defined the modules
themselves. Now the constants should always be defined.