### PR TITLE
Handle record being nil in Traits constructor

### DIFF
--- a/lib/maxmind/geoip2/record/traits.rb
+++ b/lib/maxmind/geoip2/record/traits.rb
@@ -13,7 +13,7 @@ module MaxMind
         # @!visibility private
         def initialize(record)
           super(record)
-          if !record.key?('network') && record.key?('ip_address') &&
+          if record && !record.key?('network') && record.key?('ip_address') &&
              record.key?('prefix_length')
             ip = IPAddr.new(record['ip_address']).mask(record['prefix_length'])
             # We could use ip.prefix instead of record['prefix_length'], but that
@@ -69,7 +69,7 @@ module MaxMind
         # NAT, this may differ from the IP address locally assigned to it. This
         # attribute is returned by all end points.
         #
-        # @return [String]
+        # @return [String, nil]
         def ip_address
           get('ip_address')
         end
@@ -149,7 +149,7 @@ module MaxMind
         # this is the largest network where all of the fields besides ip_address
         # have the same value.
         #
-        # @return [String]
+        # @return [String, nil]
         def network
           get('network')
         end

--- a/test/test_model_country.rb
+++ b/test/test_model_country.rb
@@ -77,4 +77,20 @@ class CountryModelTest < Minitest::Test
     model = MaxMind::GeoIP2::Model::Country.new(RAW, ['en'])
     assert_raises(NoMethodError) { model.traits.unknown }
   end
+
+  # This can happen if we're being created from a not fully populated response
+  # when used by minFraud. It shouldn't ever happen from GeoIP2 though.
+  def test_no_traits
+    model = MaxMind::GeoIP2::Model::Country.new(
+      {
+        'continent' => {
+          'code' => 'NA',
+          'geoname_id' => 42,
+          'names' => { 'en' => 'North America' },
+        },
+      },
+      ['en'],
+    )
+    assert_equal(42, model.continent.geoname_id)
+  end
 end


### PR DESCRIPTION
While this won't happen due to GeoIP2 lookups, it can happen if we're
creating an object through a less than fully populated object when used
from the minFraud gem.