### PR TITLE
Proxy params to via are positional arguments. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   `MaxMind::GeoIP2::Reader.new(database: 'GeoIP2-Country.mmdb')` instead of
   using positional arguments. This is intended to make it easier to pass in
   optional arguments. Positional argument calling is still supported.
+* Bugfix: Fixed proxy support ([#30](https://github.com/maxmind/GeoIP2-ruby/pull/30))
 
 ## 0.5.0 (2020-09-25)
 

--- a/lib/maxmind/geoip2/client.rb
+++ b/lib/maxmind/geoip2/client.rb
@@ -245,11 +245,11 @@ module MaxMind
 
         proxy = timeout
         if @proxy_address != ''
-          opts = {}
-          opts[:proxy_port] = @proxy_port if @proxy_port != 0
-          opts[:proxy_username] = @proxy_username if @proxy_username != ''
-          opts[:proxy_password] = @proxy_password if @proxy_password != ''
-          proxy = timeout.via(@proxy_address, opts)
+          proxy_params = [@proxy_address]
+          proxy_params << (@proxy_port == 0 ? nil : @proxy_port)
+          proxy_params << (@proxy_username == '' ? nil : @proxy_username)
+          proxy_params << (@proxy_password == '' ? nil : @proxy_password)
+          proxy = timeout.via(*proxy_params)
         end
 
         proxy


### PR DESCRIPTION
The current proxy configuration never worked.

Documentation from HTTP.rb on proxy support: https://github.com/httprb/http/wiki/Proxy-Support