### PR TITLE
Explicitly set the defaults in case 'nil' is passed in.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.1
+
+* Ensured defaults are set when creating the client in the case when args are
+  explicitly passed in as `nil`. Pull Request by Manoj Dayaram. Github #31
+
 ## 0.6.0 (2021-03-23)
 
 * Updated the `MaxMind::GeoIP2::Reader` constructor to support being called

--- a/lib/maxmind/geoip2/client.rb
+++ b/lib/maxmind/geoip2/client.rb
@@ -55,6 +55,8 @@ module MaxMind
     #   puts record.country.iso_code
     class Client
       # rubocop:disable Metrics/ParameterLists
+      # rubocop:disable Metrics/CyclomaticComplexity
+      # rubocop:disable Metrics/PerceivedComplexity
 
       # Create a Client that may be used to query a GeoIP2 Precision web service.
       #
@@ -98,19 +100,21 @@ module MaxMind
       )
         @account_id = account_id
         @license_key = license_key
-        @locales = locales
-        @host = host
-        @timeout = timeout
-        @proxy_address = proxy_address
-        @proxy_port = proxy_port
-        @proxy_username = proxy_username
-        @proxy_password = proxy_password
-        @pool_size = pool_size
+        @locales = locales || ['en']
+        @host = host || 'geoip.maxmind.com'
+        @timeout = timeout || 0
+        @proxy_address = proxy_address || ''
+        @proxy_port = proxy_port || 0
+        @proxy_username = proxy_username || ''
+        @proxy_password = proxy_password || ''
+        @pool_size = pool_size || 5
 
         @connection_pool = ConnectionPool.new(size: @pool_size) do
           make_http_client.persistent("https://#{@host}")
         end
       end
+      # rubocop:enable Metrics/PerceivedComplexity
+      # rubocop:enable Metrics/CyclomaticComplexity
       # rubocop:enable Metrics/ParameterLists
 
       # This method calls the City web service.


### PR DESCRIPTION
This one is a bit up for debate.  The use case that I've run into is during testing, but I can see this being an issue in production code as well.  Often times, arguments for a method could be built up incrementally:

```
arg1 = <complex operation that could end in nil>
arg2 = <complex operation that could end in nil>

my_method(arg1: arg1, arg2: arg2)
```

Even though the keyword arg default is set, that gets overriden if you explicitly pass in `nil`.   This code change would ensure that if `nil` is passed, we're still setting the defaults mentioned in the documentation.