### PR TITLE
Introduce error base classes

### DIFF
--- a/lib/maxmind/geoip2/errors.rb
+++ b/lib/maxmind/geoip2/errors.rb
@@ -2,40 +2,49 @@
 
 module MaxMind
   module GeoIP2
+    # Module's base error class
+    class Error < StandardError
+    end
+    
+    # Base error class for all errors that originate from the IP address
+    # itself and will not change when retried.
+    class AddressError < Error
+    end
+    
     # An AddressNotFoundError means the IP address was not found in the
     # database or the web service said the IP address was not found.
-    class AddressNotFoundError < RuntimeError
+    class AddressNotFoundError < AddressError
     end
 
     # An HTTPError means there was an unexpected HTTP status or response.
-    class HTTPError < RuntimeError
+    class HTTPError < Error
     end
 
     # An AddressInvalidError means the IP address was invalid.
-    class AddressInvalidError < RuntimeError
+    class AddressInvalidError < AddressError
     end
 
     # An AddressReservedError means the IP address is reserved.
-    class AddressReservedError < RuntimeError
+    class AddressReservedError < AddressError
     end
 
     # An AuthenticationError means there was a problem authenticating to the
     # web service.
-    class AuthenticationError < RuntimeError
+    class AuthenticationError < Error
     end
 
     # An InsufficientFundsError means the account is out of credits.
-    class InsufficientFundsError < RuntimeError
+    class InsufficientFundsError < Error
     end
 
     # A PermissionRequiredError means the account does not have permission to
     # use the requested service.
-    class PermissionRequiredError < RuntimeError
+    class PermissionRequiredError < Error
     end
 
     # An InvalidRequestError means the web service returned an error and there
     # is no more specific error class.
-    class InvalidRequestError < RuntimeError
+    class InvalidRequestError < Error
     end
   end
 end

--- a/lib/maxmind/geoip2/errors.rb
+++ b/lib/maxmind/geoip2/errors.rb
@@ -5,12 +5,12 @@ module MaxMind
     # Module's base error class
     class Error < StandardError
     end
-    
+
     # Base error class for all errors that originate from the IP address
     # itself and will not change when retried.
     class AddressError < Error
     end
-    
+
     # An AddressNotFoundError means the IP address was not found in the
     # database or the web service said the IP address was not found.
     class AddressNotFoundError < AddressError


### PR DESCRIPTION
This PR introduces two base classes for errors: a generic one so all MaxMind::GeoIP2-errors can be rescued
```ruby
begin
  ...
rescue MaxMind::GeopIP2::Error => e
  ...
end
```
and one serving as base class for all IP address related errors (which will not change when retried with the same address)
```ruby
begin
  ...
rescue MaxMind::GeopIP2::AddressError => e
  puts "this address is somehow invalid and will stay that way"
end
```

These changes allow for better error handling when using this library.