### PR TITLE
Remove unneeded files from the gem package

### DIFF
--- a/maxmind-geoip2.gemspec
+++ b/maxmind-geoip2.gemspec
@@ -7,7 +7,7 @@ require 'maxmind/geoip2/version'
 
 Gem::Specification.new do |s|
   s.authors     = ['William Storey']
-  s.files       = Dir['**/*'].difference(Dir['.github/**/*', 'dev-bin/**/*', 'Gemfile*'])
+  s.files       = Dir['**/*'].difference(Dir['.github/**/*', 'dev-bin/**/*', 'test/**/*', 'CLAUDE.md', 'Gemfile*', 'Rakefile', '*.gemspec'])
   s.name        = 'maxmind-geoip2'
   s.summary     = 'A gem for interacting with the GeoIP2 webservices and databases.'
   s.version     = MaxMind::GeoIP2::VERSION


### PR DESCRIPTION
There are a bunch of files in the gem package that aren't useful for downstream projects. Removing these reduces the gem package size from **294K** to **26K**, a reduction of **91%**!.

### Gem contents diff

```patch
  CHANGELOG.md
- CLAUDE.md
  LICENSE-APACHE
  LICENSE-MIT
  README.dev.md
  README.md
- Rakefile
  lib/maxmind/geoip2.rb
  lib/maxmind/geoip2/client.rb
  lib/maxmind/geoip2/errors.rb
  lib/maxmind/geoip2/model/abstract.rb
  lib/maxmind/geoip2/model/anonymous_ip.rb
  lib/maxmind/geoip2/model/anonymous_plus.rb
  lib/maxmind/geoip2/model/asn.rb
  lib/maxmind/geoip2/model/city.rb
  lib/maxmind/geoip2/model/connection_type.rb
  lib/maxmind/geoip2/model/country.rb
  lib/maxmind/geoip2/model/domain.rb
  lib/maxmind/geoip2/model/enterprise.rb
  lib/maxmind/geoip2/model/insights.rb
  lib/maxmind/geoip2/model/isp.rb
  lib/maxmind/geoip2/reader.rb
  lib/maxmind/geoip2/record/abstract.rb
  lib/maxmind/geoip2/record/anonymizer.rb
  lib/maxmind/geoip2/record/city.rb
  lib/maxmind/geoip2/record/continent.rb
  lib/maxmind/geoip2/record/country.rb
  lib/maxmind/geoip2/record/location.rb
  lib/maxmind/geoip2/record/maxmind.rb
  lib/maxmind/geoip2/record/place.rb
  lib/maxmind/geoip2/record/postal.rb
  lib/maxmind/geoip2/record/represented_country.rb
  lib/maxmind/geoip2/record/subdivision.rb
  lib/maxmind/geoip2/record/traits.rb
  lib/maxmind/geoip2/version.rb
- maxmind-geoip2.gemspec
- test/data/LICENSE-APACHE
- test/data/LICENSE-MIT
- test/data/MaxMind-DB-spec.md
- test/data/README.md
- test/data/bad-data/README.md
- test/data/bad-data/libmaxminddb/libmaxminddb-offset-integer-overflow.mmdb
- test/data/bad-data/maxminddb-golang/cyclic-data-structure.mmdb
- test/data/bad-data/maxminddb-golang/invalid-bytes-length.mmdb
- test/data/bad-data/maxminddb-golang/invalid-data-record-offset.mmdb
- test/data/bad-data/maxminddb-golang/invalid-map-key-length.mmdb
- test/data/bad-data/maxminddb-golang/invalid-string-length.mmdb
- test/data/bad-data/maxminddb-golang/metadata-is-an-uint128.mmdb
- test/data/bad-data/maxminddb-golang/unexpected-bytes.mmdb
- test/data/bad-data/maxminddb-python/bad-unicode-in-map-key.mmdb
- test/data/cmd/write-test-data/main.go
- test/data/go.mod
- test/data/go.sum
- test/data/pkg/writer/decoder.go
- test/data/pkg/writer/geoip2.go
- test/data/pkg/writer/ip.go
- test/data/pkg/writer/maxmind.go
- test/data/pkg/writer/nestedstructures.go
- test/data/pkg/writer/writer.go
- test/data/source-data/GeoIP-Anonymous-Plus-Test.json
- test/data/source-data/GeoIP2-Anonymous-IP-Test.json
- test/data/source-data/GeoIP2-City-Test.json
- test/data/source-data/GeoIP2-Connection-Type-Test.json
- test/data/source-data/GeoIP2-Country-Test.json
- test/data/source-data/GeoIP2-DensityIncome-Test.json
- test/data/source-data/GeoIP2-Domain-Test.json
- test/data/source-data/GeoIP2-Enterprise-Test.json
- test/data/source-data/GeoIP2-IP-Risk-Test.json
- test/data/source-data/GeoIP2-ISP-Test.json
- test/data/source-data/GeoIP2-Precision-Enterprise-Sandbox-Test.json
- test/data/source-data/GeoIP2-Precision-Enterprise-Test.json
- test/data/source-data/GeoIP2-Static-IP-Score-Test.json
- test/data/source-data/GeoIP2-User-Count-Test.json
- test/data/source-data/GeoLite2-ASN-Test.json
- test/data/source-data/GeoLite2-City-Test.json
- test/data/source-data/GeoLite2-Country-Test.json
- test/data/test-data/GeoIP-Anonymous-Plus-Test.mmdb
- test/data/test-data/GeoIP2-Anonymous-IP-Test.mmdb
- test/data/test-data/GeoIP2-City-Test-Broken-Double-Format.mmdb
- test/data/test-data/GeoIP2-City-Test-Invalid-Node-Count.mmdb
- test/data/test-data/GeoIP2-City-Test.mmdb
- test/data/test-data/GeoIP2-Connection-Type-Test.mmdb
- test/data/test-data/GeoIP2-Country-Test.mmdb
- test/data/test-data/GeoIP2-DensityIncome-Test.mmdb
- test/data/test-data/GeoIP2-Domain-Test.mmdb
- test/data/test-data/GeoIP2-Enterprise-Test.mmdb
- test/data/test-data/GeoIP2-IP-Risk-Test.mmdb
- test/data/test-data/GeoIP2-ISP-Test.mmdb
- test/data/test-data/GeoIP2-Precision-Enterprise-Test.mmdb
- test/data/test-data/GeoIP2-Static-IP-Score-Test.mmdb
- test/data/test-data/GeoIP2-User-Count-Test.mmdb
- test/data/test-data/GeoLite2-ASN-Test.mmdb
- test/data/test-data/GeoLite2-City-Test.mmdb
- test/data/test-data/GeoLite2-Country-Test.mmdb
- test/data/test-data/MaxMind-DB-no-ipv4-search-tree.mmdb
- test/data/test-data/MaxMind-DB-string-value-entries.mmdb
- test/data/test-data/MaxMind-DB-test-broken-pointers-24.mmdb
- test/data/test-data/MaxMind-DB-test-broken-search-tree-24.mmdb
- test/data/test-data/MaxMind-DB-test-decoder.mmdb
- test/data/test-data/MaxMind-DB-test-ipv4-24.mmdb
- test/data/test-data/MaxMind-DB-test-ipv4-28.mmdb
- test/data/test-data/MaxMind-DB-test-ipv4-32.mmdb
- test/data/test-data/MaxMind-DB-test-ipv6-24.mmdb
- test/data/test-data/MaxMind-DB-test-ipv6-28.mmdb
- test/data/test-data/MaxMind-DB-test-ipv6-32.mmdb
- test/data/test-data/MaxMind-DB-test-metadata-pointers.mmdb
- test/data/test-data/MaxMind-DB-test-mixed-24.mmdb
- test/data/test-data/MaxMind-DB-test-mixed-28.mmdb
- test/data/test-data/MaxMind-DB-test-mixed-32.mmdb
- test/data/test-data/MaxMind-DB-test-nested.mmdb
- test/data/test-data/MaxMind-DB-test-pointer-decoder.mmdb
- test/data/test-data/README.md
- test/data/test-data/maps-with-pointers.raw
- test/data/tidyall.ini
- test/test_client.rb
- test/test_model_country.rb
- test/test_model_names.rb
- test/test_reader.rb
```