### PR TITLE
Clarify when ip_risk_snapshot is not populated

### DIFF
--- a/lib/maxmind/geoip2/record/traits.rb
+++ b/lib/maxmind/geoip2/record/traits.rb
@@ -242,7 +242,15 @@ module MaxMind
         # services is more static than the IP risk score provided in minFraud
         # and is not responsive to traffic on your network. If you need realtime
         # IP risk scoring based on behavioral signals on your own network, please
-        # use minFraud. This property is only available from Insights.
+        # use minFraud.
+        #
+        # We do not provide an IP risk snapshot for low-risk networks. If this
+        # field is not populated, we either do not have signals for the network
+        # or the signals we have show that the network is low-risk. If you would
+        # like to get signals for low-risk networks, please use the minFraud web
+        # services.
+        #
+        # This property is only available from Insights.
         #
         # @return [Float, nil]
         def ip_risk_snapshot


### PR DESCRIPTION
Add documentation explaining that the IP risk snapshot is not provided for low-risk networks, and that a nil value indicates either no signals or low-risk signals for the network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)