### PR TITLE
Pin GitHub Actions to SHA for security

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           submodules: true
           persist-credentials: false

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -12,7 +12,7 @@ jobs:
   rubocop:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
           - os: windows-latest
             version: jruby
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           submodules: true
           persist-credentials: false

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -15,7 +15,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
 


### PR DESCRIPTION
## Summary

- Pin official GitHub Actions (`actions/*`, `github/*`) to specific commit SHAs
- Satisfies zizmor's `unpinned-action-reference` security check
- All actions upgraded to latest versions

## Changes

Updates workflow files to use pinned SHA references instead of version tags:
- `actions/checkout@v6` → `actions/checkout@<sha> # v6.0.1`
- `github/codeql-action/*@v4` → `github/codeql-action/*@<sha> # v4.31.9`
- And similar for other official actions

## Test plan

- [ ] CI passes with pinned actions
- [ ] zizmor check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)